### PR TITLE
ActiveSupport::Cache::CouchbaseStore#write_entry should raise Couchbase::Error::KeyExists

### DIFF
--- a/lib/active_support/cache/couchbase_store.rb
+++ b/lib/active_support/cache/couchbase_store.rb
@@ -315,7 +315,7 @@ module ActiveSupport
         @data.send(method, key, value, options)
       rescue Couchbase::Error::Base => e
         logger.error("#{e.class}: #{e.message}") if logger
-        raise if @raise_errors
+        raise if @raise_errors || method == :add
         false
       end
 

--- a/test/test_couchbase_rails_cache_store.rb
+++ b/test/test_couchbase_rails_cache_store.rb
@@ -73,7 +73,9 @@ class TestCouchbaseRailsCacheStore < MiniTest::Unit::TestCase
   def test_it_doest_write_data_if_unless_exist_option_is_true
     store.write uniq_id, @foo
     [:unless_exist, :unless_exists].each do |unless_exists|
-      store.write uniq_id, @foobar, unless_exists => true
+      assert_raises(Couchbase::Error::KeyExists) do
+        store.write uniq_id, @foobar, unless_exists => true
+      end
       assert_equal @foo, store.read(uniq_id)
     end
   end


### PR DESCRIPTION
when `:unless_exists => true` irrespective of `quiet` or `raise_errors` setting.

This is as per the behavior of store as specified in `TestStore#test_add`
