### PR TITLE
use global scope to find Error classes

### DIFF
--- a/lib/rack/session/couchbase.rb
+++ b/lib/rack/session/couchbase.rb
@@ -90,7 +90,7 @@ module Rack
       def with_lock(env, default = nil)
         @mutex.lock if env['rack.multithread']
         yield
-      rescue Couchbase::Error::Connect, Couchbase::Error::Timeout
+      rescue ::Couchbase::Error::Connect, ::Couchbase::Error::Timeout
         if $VERBOSE
           warn "#{self} is unable to find Couchbase server."
           warn $!.inspect


### PR DESCRIPTION
The Rack::Session::Couchbase class hides global CouchBase so can't find Error classes unless the global scoping operator is used
