### PR TITLE
Fix JSON post in rails

### DIFF
--- a/lib/ext/multi_json_fix.rb
+++ b/lib/ext/multi_json_fix.rb
@@ -38,7 +38,7 @@ if multi_json_engine.name =~ /JsonGem$/
   class << multi_json_engine
     alias _load_object load
     def load(string, options = {})
-      if string =~ /\A\s*[{\[]/
+      if !string.is_a?(String) || string =~ /\A\s*[{\[]/
         _load_object(string, options)
       else
         _load_object("[#{string}]", options)[0]


### PR DESCRIPTION
When posting JSON strings in rails this function is passed a StringIO object not a string.
This causes the following error:

`MultiJson::DecodeError`
`399: unexpected token at '#<StringIO:0x2f64720>]'`

json (1.7.5) lib/json/common.rb:155:in `parse&#x27;
json (1.7.5) lib/json/common.rb:155:in`parse&#x27;
multi_json (1.3.7) lib/multi_json/adapters/json_common.rb:7:in `load&#x27;
couchbase-1.2.0.z.beta4-x86 (mingw32) lib/ext/multi_json_fix.rb:44:in`load&#x27;
multi_json (1.3.7) lib/multi_json.rb:96:in `load&#x27;
activesupport (3.2.9) lib/active_support/json/decoding.rb:15:in`decode&#x27;
actionpack (3.2.9) lib/action_dispatch/middleware/params_parser.rb:47:in `parse_formatted_parameters&#x27;
actionpack (3.2.9) lib/action_dispatch/middleware/params_parser.rb:17:in`call&#x27;
actionpack (3.2.9) lib/action_dispatch/middleware/flash.rb:242:in `call&#x27;
rack (1.4.1) lib/rack/session/abstract/id.rb:205:in`context&#x27;
rack (1.4.1) lib/rack/session/abstract/id.rb:200:in `call&#x27;
actionpack (3.2.9) lib/action_dispatch/middleware/cookies.rb:341:in`call&#x27;
actionpack (3.2.9) lib/action_dispatch/middleware/callbacks.rb:28:in `block in call&#x27;
activesupport (3.2.9) lib/active_support/callbacks.rb:405:in`_run__961998876__call__1018806479__callbacks&#x27;
activesupport (3.2.9) lib/active_support/callbacks.rb:405:in `__run_callback&#x27;
activesupport (3.2.9) lib/active_support/callbacks.rb:385:in`_run_call_callbacks&#x27;
activesupport (3.2.9) lib/active_support/callbacks.rb:81:in `run_callbacks&#x27;
actionpack (3.2.9) lib/action_dispatch/middleware/callbacks.rb:27:in`call&#x27;
actionpack (3.2.9) lib/action_dispatch/middleware/reloader.rb:65:in `call&#x27;
actionpack (3.2.9) lib/action_dispatch/middleware/remote_ip.rb:31:in`call&#x27;
actionpack (3.2.9) lib/action_dispatch/middleware/debug_exceptions.rb:16:in `call&#x27;
actionpack (3.2.9) lib/action_dispatch/middleware/show_exceptions.rb:56:in`call&#x27;
railties (3.2.9) lib/rails/rack/logger.rb:32:in `call_app&#x27;
railties (3.2.9) lib/rails/rack/logger.rb:16:in`block in call&#x27;
activesupport (3.2.9) lib/active_support/tagged_logging.rb:22:in `tagged&#x27;
railties (3.2.9) lib/rails/rack/logger.rb:16:in`call&#x27;
actionpack (3.2.9) lib/action_dispatch/middleware/request_id.rb:22:in `call&#x27;
rack (1.4.1) lib/rack/methodoverride.rb:21:in`call&#x27;
rack (1.4.1) lib/rack/runtime.rb:17:in `call&#x27;
activesupport (3.2.9) lib/active_support/cache/strategy/local_cache.rb:72:in`call&#x27;
rack (1.4.1) lib/rack/lock.rb:15:in `call&#x27;
actionpack (3.2.9) lib/action_dispatch/middleware/static.rb:62:in`call&#x27;
railties (3.2.9) lib/rails/engine.rb:479:in `call&#x27;
railties (3.2.9) lib/rails/application.rb:223:in`call&#x27;
rack (1.4.1) lib/rack/content_length.rb:14:in `call&#x27;
railties (3.2.9) lib/rails/rack/log_tailer.rb:17:in`call&#x27;
thin (1.5.0) lib/thin/connection.rb:81:in `block in pre_process&#x27;
thin (1.5.0) lib/thin/connection.rb:79:in`catch&#x27;
thin (1.5.0) lib/thin/connection.rb:79:in `pre_process&#x27;
thin (1.5.0) lib/thin/connection.rb:54:in`process&#x27;
thin (1.5.0) lib/thin/connection.rb:39:in `receive_data&#x27;
eventmachine-1.0.0-x86 (mingw32) lib/eventmachine.rb:187:in`run_machine&#x27;
eventmachine-1.0.0-x86 (mingw32) lib/eventmachine.rb:187:in `run&#x27;
thin (1.5.0) lib/thin/backends/base.rb:63:in`start&#x27;
thin (1.5.0) lib/thin/server.rb:159:in `start&#x27;
rack (1.4.1) lib/rack/handler/thin.rb:13:in`run&#x27;
rack (1.4.1) lib/rack/server.rb:265:in `start&#x27;
railties (3.2.9) lib/rails/commands/server.rb:70:in`start&#x27;
railties (3.2.9) lib/rails/commands.rb:55:in `block in &lt;top (required)&gt;&#x27;
railties (3.2.9) lib/rails/commands.rb:50:in`tap&#x27;
railties (3.2.9) lib/rails/commands.rb:50:in `&lt;top (required)&gt;&#x27;
