### PR TITLE
Reset Couchbase#thread_storage when a Kernel#fork is detected. Adding to...

### DIFF
--- a/test/test_couchbase.rb
+++ b/test/test_couchbase.rb
@@ -16,12 +16,59 @@
 #
 
 require File.join(File.dirname(__FILE__), 'setup')
+require 'minitest/mock'
 
 class TestCouchbase < MiniTest::Unit::TestCase
+
+  def teardown
+    Couchbase.reset_thread_storage!
+  end
 
   def test_that_it_create_instance_of_bucket
     with_mock do |mock|
       assert_instance_of Couchbase::Bucket, Couchbase.new("http://#{mock.host}:#{mock.port}/pools/default")
+    end
+  end
+
+  def test_verify_connection
+    pid = Process.pid
+    assert_equal pid, Couchbase.thread_storage[:pid]
+    Couchbase.verify_connection!
+    assert_equal pid, Couchbase.thread_storage[:pid]
+  end
+
+  def test_verify_connection_when_process_forks
+    pid = Process.pid
+    assert_equal pid, Couchbase.thread_storage[:pid]
+      
+    # stub a simulated Kernel#fork
+    Process.stub(:pid, Process.pid + 1) do
+      Couchbase.verify_connection!
+      refute_equal pid, Couchbase.thread_storage[:pid]
+    end
+  end
+
+  def test_new_connection_when_process_forks
+    with_mock do |mock|
+      old_bucket_id = Couchbase.bucket.object_id
+
+      Process.stub(:pid, Process.pid + 1) do
+        refute_equal old_bucket_id, Couchbase.bucket.object_id
+      end
+    end
+  end
+
+  def test_new_connection_has_same_configuration_options
+    with_mock do |mock|
+      connection_options = "http://#{mock.host}:#{mock.port}/pools/default"
+      Couchbase.connection_options = connection_options
+      old_bucket = Couchbase.bucket
+
+      Process.stub(:pid, Process.pid + 1) do
+        new_bucket = Couchbase.bucket
+        assert_equal old_bucket.name, new_bucket.name
+        assert_equal old_bucket.hostname, new_bucket.hostname
+      end
     end
   end
 


### PR DESCRIPTION
... avoid file descriptor sharing between a process and its sub process. See section 13.3 at http://www.modrails.com/documentation/Users%20guide%20Apache.html for a description of why this is bad.

Change-Id: I6019aaf3635c3f9f31076f6ac5d5d978978c718f

Dupe of http://review.couchbase.org/#/c/25266/
