### PR TITLE
Fix JSON monkey patch for StringIO-like objects

### DIFF
--- a/lib/ext/multi_json_fix.rb
+++ b/lib/ext/multi_json_fix.rb
@@ -43,7 +43,7 @@ if multi_json_engine.name =~ /JsonGem$/
   class << multi_json_engine
     alias _load_object load
     def load(string, options = {})
-      if string.is_a?(StringIO)
+      if string.respond_to?(:read)
         string = string.read
       end
       if string =~ /\A\s*[{\[]/


### PR DESCRIPTION
#read's all objects with a StringIO-like interface, not only StringIO itself. One use-case being
Unicorn::TeeInput, but others may exist.