### PR TITLE
Fixed a memory leak introduced by "Use exceptfds in multithread plugin"

### DIFF
--- a/ext/couchbase_ext/multithread_plugin.c
+++ b/ext/couchbase_ext/multithread_plugin.c
@@ -558,6 +558,7 @@ ls_arg_free(void *p) {
     if (args) {
         rb_fd_term(&args->in);
         rb_fd_term(&args->out);
+        rb_fd_term(&args->exc);
         xfree(args);
     }
 }


### PR DESCRIPTION
Here is the commit that introduced the leak, I believe.
https://github.com/couchbase/couchbase-ruby-client/commit/2b6830db1dcf9dcde1fd9853de72f52cde05907d

References:
https://forums.couchbase.com/t/couchbase-bucket-leaks-memory/1932
https://issues.couchbase.com/browse/RCBC-187