### PR TITLE
TypeError: superclass mismatch for class InvalidArgument

### DIFF
--- a/lib/couchbase/errors.rb
+++ b/lib/couchbase/errors.rb
@@ -19,9 +19,6 @@ module Couchbase
     class RequestCanceled < StandardError
     end
 
-    class InvalidArgumentError < ArgumentError
-    end
-
     class ServiceNotAvailable < StandardError
     end
 

--- a/lib/couchbase/errors.rb
+++ b/lib/couchbase/errors.rb
@@ -19,7 +19,7 @@ module Couchbase
     class RequestCanceled < StandardError
     end
 
-    class InvalidArgument < ArgumentError
+    class InvalidArgumentError < ArgumentError
     end
 
     class ServiceNotAvailable < StandardError


### PR DESCRIPTION
This fixes an error on starting `bin/console` on ruby 2.6.3.
```
couchbase-ruby-client (master)$ bin/console
Traceback (most recent call last):
        14: from bin/console:19:in `<main>'
        13: from bin/console:19:in `require'
        12: from /Users/k/Projects/couchbase-ruby-client/lib/couchbase.rb:17:in `<top (required)>'
        11: from /Users/k/Projects/couchbase-ruby-client/lib/couchbase.rb:17:in `require'
        10: from /Users/k/Projects/couchbase-ruby-client/lib/couchbase/cluster.rb:16:in `<top (required)>'
         9: from /Users/k/Projects/couchbase-ruby-client/lib/couchbase/cluster.rb:16:in `require'
         8: from /Users/k/Projects/couchbase-ruby-client/lib/couchbase/bucket.rb:15:in `<top (required)>'
         7: from /Users/k/Projects/couchbase-ruby-client/lib/couchbase/bucket.rb:15:in `require'
         6: from /Users/k/Projects/couchbase-ruby-client/lib/couchbase/scope.rb:15:in `<top (required)>'
         5: from /Users/k/Projects/couchbase-ruby-client/lib/couchbase/scope.rb:15:in `require'
         4: from /Users/k/Projects/couchbase-ruby-client/lib/couchbase/collection.rb:15:in `<top (required)>'
         3: from /Users/k/Projects/couchbase-ruby-client/lib/couchbase/collection.rb:15:in `require'
         2: from /Users/k/Projects/couchbase-ruby-client/lib/couchbase/errors.rb:15:in `<top (required)>'
         1: from /Users/k/Projects/couchbase-ruby-client/lib/couchbase/errors.rb:16:in `<module:Couchbase>'
/Users/k/Projects/couchbase-ruby-client/lib/couchbase/errors.rb:22:in `<module:Error>': superclass mismatch for class InvalidArgument (TypeError)
```