### PR TITLE
RCBC-388: Add Configuration Profiles

### DIFF
--- a/lib/couchbase/config_profiles.rb
+++ b/lib/couchbase/config_profiles.rb
@@ -27,11 +27,9 @@ module Couchbase
       end
 
       def apply(profile_name, options)
-        if @profiles.key?(profile_name)
-          @profiles[profile_name].apply(options)
-          return
-        end
-        raise ArgumentError, "#{profile_name} is not a registered profile"
+        raise ArgumentError, "#{profile_name} is not a registered profile" unless @profiles.key?(profile_name)
+
+        @profiles[profile_name].apply(options)
       end
     end
 

--- a/lib/couchbase/config_profiles.rb
+++ b/lib/couchbase/config_profiles.rb
@@ -18,7 +18,7 @@ module Couchbase
       attr :profiles
 
       def initialize
-        @profiles = Hash.new
+        @profiles = {}
         register_profile("wan_development", DevelopmentProfile.new)
       end
 
@@ -42,7 +42,7 @@ module Couchbase
     class DevelopmentProfile < Profile
       def apply(options)
         options.key_value_timeout = 20 * 1000
-        # TODO Add `options.key_value_durable_timeout = 20 * 1000` when key_value_durable_timeout is added to Options::Cluster
+        # TODO: Add `options.key_value_durable_timeout = 20 * 1000` when key_value_durable_timeout is added to Options::Cluster
         options.connect_timeout = 20 * 1000
         options.view_timeout = 120 * 1000
         options.query_timeout = 120 * 1000
@@ -53,6 +53,5 @@ module Couchbase
     end
 
     KNOWN_PROFILES = Profiles.new
-
   end
 end

--- a/lib/couchbase/config_profiles.rb
+++ b/lib/couchbase/config_profiles.rb
@@ -1,0 +1,58 @@
+#  Copyright 2020-2022 Couchbase, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+module Couchbase
+  module ConfigProfiles
+    class Profiles
+      attr :profiles
+
+      def initialize
+        @profiles = Hash.new
+        register_profile("wan_development", DevelopmentProfile.new)
+      end
+
+      def register_profile(name, profile)
+        @profiles[name] = profile
+      end
+
+      def apply(profile_name, options)
+        if @profiles.key?(profile_name)
+          @profiles[profile_name].apply(options)
+          return
+        end
+        raise ArgumentError, "#{profile_name} is not a registered profile"
+      end
+    end
+
+    class Profile
+      def apply(options); end
+    end
+
+    class DevelopmentProfile < Profile
+      def apply(options)
+        options.key_value_timeout = 20 * 1000
+        # TODO Add `options.key_value_durable_timeout = 20 * 1000` when key_value_durable_timeout is added to Options::Cluster
+        options.connect_timeout = 20 * 1000
+        options.view_timeout = 120 * 1000
+        options.query_timeout = 120 * 1000
+        options.analytics_timeout = 120 * 1000
+        options.search_timeout = 120 * 1000
+        options.management_timeout = 120 * 1000
+      end
+    end
+
+    KNOWN_PROFILES = Profiles.new
+
+  end
+end

--- a/lib/couchbase/config_profiles.rb
+++ b/lib/couchbase/config_profiles.rb
@@ -41,14 +41,14 @@ module Couchbase
 
     class DevelopmentProfile < Profile
       def apply(options)
-        options.key_value_timeout = 20 * 1000
-        # TODO: Add `options.key_value_durable_timeout = 20 * 1000` when key_value_durable_timeout is added to Options::Cluster
-        options.connect_timeout = 20 * 1000
-        options.view_timeout = 120 * 1000
-        options.query_timeout = 120 * 1000
-        options.analytics_timeout = 120 * 1000
-        options.search_timeout = 120 * 1000
-        options.management_timeout = 120 * 1000
+        options.key_value_timeout = 20_000
+        # TODO: Add `options.key_value_durable_timeout = 20_000` when key_value_durable_timeout is added to Options::Cluster
+        options.connect_timeout = 20_000
+        options.view_timeout = 120_000
+        options.query_timeout = 120_000
+        options.analytics_timeout = 120_000
+        options.search_timeout = 120_000
+        options.management_timeout = 120_000
       end
     end
 

--- a/lib/couchbase/options.rb
+++ b/lib/couchbase/options.rb
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 require "couchbase/utils/time"
+require "couchbase/config_profiles"
 
 module Couchbase
   # Definition of the Option classes for data APIs
@@ -1459,6 +1460,11 @@ module Couchbase
       # @param [String] password
       def authenticate(username, password)
         @authenticator = PasswordAuthenticator.new(username, password)
+      end
+
+      # @param [String] profile_name The name of the configuration profile to apply (e.g. "wan_development")
+      def apply_profile(profile_name)
+        ConfigProfiles::KNOWN_PROFILES.apply(profile_name, self)
       end
 
       # @api private

--- a/test/config_profiles_test.rb
+++ b/test/config_profiles_test.rb
@@ -1,0 +1,56 @@
+#  Copyright 2020-2022 Couchbase, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+require_relative "test_helper"
+
+module Couchbase
+  class ConfigProfilesTest < Minitest::Test
+    include TestUtilities
+
+    class CustomProfile < Couchbase::ConfigProfiles::Profile
+      def apply(options)
+        options.key_value_timeout = 15000
+        options.connect_timeout = 17000
+      end
+    end
+
+    def setup
+      # Do nothing
+    end
+
+    def teardown
+      # Do nothing
+    end
+
+    def test_apply_development_config_profile
+      options = Couchbase::Options::Cluster.new
+      options.apply_profile("wan_development")
+      assert_equal 20000, options.key_value_timeout
+      assert_equal 20000, options.connect_timeout
+      assert_equal 120000, options.view_timeout
+      assert_equal 120000, options.query_timeout
+      assert_equal 120000, options.analytics_timeout
+      assert_equal 120000, options.search_timeout
+      assert_equal 120000, options.management_timeout
+    end
+
+    def test_apply_custom_config_profile
+      Couchbase::ConfigProfiles::KNOWN_PROFILES.register_profile("custom_profile", CustomProfile.new)
+      options = Couchbase::Options::Cluster.new
+      options.apply_profile("custom_profile")
+      assert_equal 15000, options.key_value_timeout
+      assert_equal 17000, options.connect_timeout
+    end
+  end
+end


### PR DESCRIPTION
Adding support for configuration profiles ([RFC-0074](https://github.com/couchbaselabs/sdk-rfcs/blob/master/rfc/0074-config-profiles.md), [RCBC-388](https://issues.couchbase.com/browse/RCBC-388))

Provides the ability to apply one of the known profiles, as well as register custom profiles. A development profile has been implemented (Profile name: `"wan_development"`). 

**Applying the development profile:**

```ruby
opts = Couchbase::Cluster::ClusterOptions.new
opts.apply_profile("wan_development")
```

A custom profile is created by extending the `Profile` class and overwriting its `apply()` method. The profile should be registered before it can be applied.

**Creating a new custom profile:**

```ruby
class CustomProfile < Couchbase::ConfigProfiles::Profile
  def apply(options)
    options.key_value_timeout = 15000
    options.connect_timeout = 17000
  end
end
```

**Registering the profile:**

```ruby
Couchbase::ConfigProfiles::KNOWN_PROFILES.register_profile("custom_profile", CustomProfile.new)
```