### PR TITLE
RCBC-378: Implement change_password

### DIFF
--- a/ext/couchbase.cxx
+++ b/ext/couchbase.cxx
@@ -4594,8 +4594,9 @@ cb_Backend_change_password(VALUE self, VALUE new_password, VALUE timeout)
         req.newPassword = cb_string_new(new_password);
         auto barrier = std::make_shared<std::promise<couchbase::core::operations::management::change_password_response>>();
         auto f = barrier->get_future();
-        cluster->execute(
-          req, [barrier](couchbase::core::operations::management::change_password_response&& resp) { barrier->set_value(std::move(resp)); });
+        cluster->execute(req, [barrier](couchbase::core::operations::management::change_password_response&& resp) {
+          barrier->set_value(std::move(resp));
+        });
         if (auto resp = cb_wait_for_future(f); resp.ctx.ec) {
             cb_throw_error_code(resp.ctx, "unable to change password");
         }

--- a/ext/couchbase.cxx
+++ b/ext/couchbase.cxx
@@ -4595,7 +4595,7 @@ cb_Backend_change_password(VALUE self, VALUE new_password, VALUE timeout)
         auto barrier = std::make_shared<std::promise<couchbase::core::operations::management::change_password_response>>();
         auto f = barrier->get_future();
         cluster->execute(req, [barrier](couchbase::core::operations::management::change_password_response&& resp) {
-          barrier->set_value(std::move(resp));
+            barrier->set_value(std::move(resp));
         });
         if (auto resp = cb_wait_for_future(f); resp.ctx.ec) {
             cb_throw_error_code(resp.ctx, "unable to change password");

--- a/lib/couchbase/management/user_manager.rb
+++ b/lib/couchbase/management/user_manager.rb
@@ -101,6 +101,15 @@ module Couchbase
         end
       end
 
+      # Changes the password of the currently authenticated user
+      #
+      # @param [ChangePasswordOptions] options
+      #
+      # @raise [ArgumentError]
+      def change_password(new_password, options = ChangePasswordOptions.new)
+        @backend.change_password(new_password, options.timeout)
+      end
+
       # Gets a group
       #
       # @param [String] group_name name of the group to get
@@ -209,6 +218,16 @@ module Couchbase
         # @yieldparam [DropUserOptions] self
         def initialize
           @domain = :local
+          yield self if block_given?
+        end
+      end
+
+      class ChangePasswordOptions
+        # @return [Integer] the time in milliseconds allowed for the operation to complete
+        attr_accessor :timeout
+
+        # @yieldparam [ChangePasswordOptions] self
+        def initialize
           yield self if block_given?
         end
       end

--- a/test/user_manager_test.rb
+++ b/test/user_manager_test.rb
@@ -1,0 +1,91 @@
+#  Copyright 2020-2021 Couchbase, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+require_relative "test_helper"
+
+module Couchbase
+  class UserManagerTest < Minitest::Test
+    include TestUtilities
+
+    def setup
+      connect
+      @test_username = "test_user"
+      @test_password = "a_password"
+      @test_user = Management::User.new do |u|
+        u.username = @test_username
+        u.password = @test_password
+        u.roles = [
+          Management::Role.new do |r|
+            r.name = "data_reader"
+            r.bucket = "*"
+          end,
+          Management::Role.new do |r|
+            r.name = "query_select"
+            r.bucket = "*"
+          end,
+          Management::Role.new do |r|
+            r.name = "data_writer"
+            r.bucket = "*"
+          end,
+          Management::Role.new do |r|
+            r.name = "query_insert"
+            r.bucket = "*"
+          end,
+          Management::Role.new do |r|
+            r.name = "query_delete"
+            r.bucket = "*"
+          end,
+          Management::Role.new do |r|
+            r.name = "query_manage_index"
+            r.bucket = "*"
+          end,
+        ]
+      end
+      @cluster.users.upsert_user(@test_user)
+    end
+
+    def teardown
+      connect
+      @cluster.users.drop_user(@test_username)
+      disconnect
+    end
+
+    def test_change_password
+      skip("#{name}: CAVES does not support change_password") if use_caves?
+
+      # Connect to the cluster with the test user
+      orig_options = Cluster::ClusterOptions.new
+      orig_options.authenticate(@test_username, @test_password)
+      @cluster = Cluster.connect(@env.connection_string, orig_options)
+
+      # Change the test user's password
+      new_password = "a_new_password"
+      @cluster.users.change_password(new_password)
+
+      # Verify that the connection fails with the old password
+      assert_raises(Error::AuthenticationFailure) { Cluster.connect(@env.connection_string, orig_options) }
+
+      # Verify that the connection succeeds with the new password
+      new_options = Cluster::ClusterOptions.new
+      new_options.authenticate(@test_username, new_password)
+      @cluster = Cluster.connect(@env.connection_string, new_options)
+
+      # Change the password back to the original one
+      @cluster.users.change_password(@test_password)
+
+      # Verify that the connection fails with the new password
+      assert_raises(Error::AuthenticationFailure) { Cluster.connect(@env.connection_string, new_options) }
+    end
+  end
+end


### PR DESCRIPTION
**Changes:**
- Updated core
- Added `change_password` function in `Management::UserManager` for changing the password of the current user
- Added a relevant test in `UserManagerTest`