### PR TITLE
Add sleep after upserting user and changing password in change_password test

### DIFF
--- a/test/user_manager_test.rb
+++ b/test/user_manager_test.rb
@@ -63,6 +63,7 @@ module Couchbase
           sleep(0.01)
           next
         end
+        sleep(0.1)
         return
       end
       raise "User could not be created"
@@ -86,6 +87,8 @@ module Couchbase
       new_password = "a_new_password"
       @cluster.users.change_password(new_password)
 
+      sleep(0.1)
+
       # Verify that the connection fails with the old password
       assert_raises(Error::AuthenticationFailure) { Cluster.connect(@env.connection_string, orig_options) }
 
@@ -96,6 +99,8 @@ module Couchbase
 
       # Change the password back to the original one
       @cluster.users.change_password(@test_password)
+
+      sleep(0.1)
 
       # Verify that the connection fails with the new password
       assert_raises(Error::AuthenticationFailure) { Cluster.connect(@env.connection_string, new_options) }


### PR DESCRIPTION
This should fix the failing test on jenkins. The sleep needed seems to vary between clusters (Running locally on docker, it was fine for one cluster without a sleep, but another one needed some delay after changing the password or upserting a user, 0.1s was sufficient)