### PR TITLE
RCBC-406 & RCBC-415: Improve conversion of GRPC errors and implement retry handling

### DIFF
--- a/lib/couchbase/protostellar/cluster.rb
+++ b/lib/couchbase/protostellar/cluster.rb
@@ -39,7 +39,6 @@ module Couchbase
         channel_args = options.grpc_channel_args
 
         @client = Client.new(host, credentials, channel_args)
-
         @query_request_generator = RequestGenerator::Query.new
       end
 
@@ -53,11 +52,7 @@ module Couchbase
 
       def query(statement, options = Couchbase::Options::Query::DEFAULT)
         req = @query_request_generator.query_request(statement, options)
-        begin
-          resps = @client.query(req, timeout: options.timeout)
-        rescue GRPC::DeadlineExceeded
-          raise Couchbase::Error::Timeout
-        end
+        resps = @client.send_request(req)
         ResponseConverter::Query.from_query_responses(resps)
       end
     end

--- a/lib/couchbase/protostellar/collection.rb
+++ b/lib/couchbase/protostellar/collection.rb
@@ -38,111 +38,57 @@ module Couchbase
         @kv_request_generator = RequestGenerator::KV.new(@bucket_name, @scope_name, @name)
       end
 
-      def location
-        {
-          bucket_name: @bucket_name,
-          scope_name: @scope_name,
-          collection_name: @name,
-        }
-      end
-
       def get(id, options = Couchbase::Options::Get::DEFAULT)
         req = @kv_request_generator.get_request(id, options)
-        begin
-          resp = @client.get(req, timeout: options.timeout)
-        rescue GRPC::NotFound
-          raise Couchbase::Error::DocumentNotFound
-        rescue GRPC::DeadlineExceeded
-          throw Couchbase::Error::Timeout
-        end
+        resp = @client.send_request(req)
         ResponseConverter::KV.from_get_response(resp, options)
       end
 
       def get_and_touch(id, expiry, options = Couchbase::Options::GetAndTouch::DEFAULT)
         req = @kv_request_generator.get_and_touch_request(id, expiry, options)
-        begin
-          resp = @client.get_and_touch(req, timeout: options.timeout)
-        rescue GRPC::NotFound
-          raise Couchbase::Error::DocumentNotFound
-        rescue GRPC::DeadlineExceeded
-          throw Couchbase::Error::Timeout
-        end
+        resp = @client.send_request(req)
         ResponseConverter::KV.from_get_response(resp, options)
       end
 
       def upsert(id, content, options = Couchbase::Options::Upsert::DEFAULT)
         req = @kv_request_generator.upsert_request(id, content, options)
-        begin
-          resp = @client.upsert(req, timeout: options.timeout)
-        rescue GRPC::DeadlineExceeded
-          raise Couchbase::Error::Timeout
-        end
+        resp = @client.send_request(req)
         ResponseConverter::KV.from_upsert_response(resp)
       end
 
       def remove(id, options = Couchbase::Options::Remove::DEFAULT)
         req = @kv_request_generator.remove_request(id, options)
-        begin
-          resp = @client.remove(req, timeout: options.timeout)
-        rescue GRPC::DeadlineExceeded
-          raise Couchbase::Error::Timeout
-        rescue GRPC::NotFound
-          raise Couchbase::Error::DocumentNotFound
-        end
+        resp = @client.send_request(req)
         ResponseConverter::KV.from_remove_response(resp)
       end
 
       def insert(id, content, options = Couchbase::Options::Insert::DEFAULT)
         req = @kv_request_generator.insert_request(id, content, options)
-        begin
-          resp = @client.insert(req, timeout: options.timeout)
-        rescue GRPC::DeadlineExceeded
-          raise Couchbase::Error::Timeout
-        rescue GRPC::AlreadyExists
-          raise Couchbase::Error::DocumentExists
-        end
+        resp = @client.send_request(req)
         ResponseConverter::KV.from_insert_response(resp)
       end
 
       def replace(id, content, options = Couchbase::Options::Replace::DEFAULT)
         req = @kv_request_generator.replace_request(id, content, options)
-        begin
-          resp = @client.replace(req, timeout: options.timeout)
-        rescue GRPC::DeadlineExceeded
-          raise Couchbase::Error::Timeout
-        rescue GRPC::NotFound
-          raise Couchbase::Error::DocumentNotFound
-        end
+        resp = @client.send_request(req)
         ResponseConverter::KV.from_replace_response(resp)
       end
 
       def exists(id, options = Couchbase::Options::Exists::DEFAULT)
         req = @kv_request_generator.exists_request(id, options)
-        begin
-          resp = @client.exists(req, timeout: options.timeout)
-        rescue GRPC::DeadlineExceeded
-          raise Couchbase::Error::Timeout
-        end
+        resp = @client.send_request(req)
         ResponseConverter::KV.from_exists_response(resp)
       end
 
       def lookup_in(id, specs, options = Couchbase::Options::LookupIn::DEFAULT)
         req = @kv_request_generator.lookup_in_request(id, specs, options)
-        begin
-          resp = @client.lookup_in(req, timeout: options.timeout)
-        rescue GRPC::DeadlineExceeded
-          raise Couchbase::Error::Timeout
-        end
+        resp = @client.send_request(req)
         ResponseConverter::KV.from_lookup_in_response(resp, specs, options)
       end
 
       def mutate_in(id, specs, options = Couchbase::Options::MutateIn::DEFAULT)
         req = @kv_request_generator.mutate_in_request(id, specs, options)
-        begin
-          resp = @client.mutate_in(req, timeout: options.timeout)
-        rescue GRPC::DeadlineExceeded
-          raise Couchbase::Error::Timeout
-        end
+        resp = @client.send_request(req)
         ResponseConverter::KV.from_mutate_in_response(resp, specs, options)
       end
     end

--- a/lib/couchbase/protostellar/error.rb
+++ b/lib/couchbase/protostellar/error.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Couchbase
+  # Error types for internal protostellar errors
+  module Protostellar
+    module Error
+      class ProtostellarError < StandardError
+      end
+
+      class UnexpectedServiceType < ProtostellarError
+      end
+
+      class InvalidRetryBehaviour < ProtostellarError
+      end
+    end
+  end
+end

--- a/lib/couchbase/protostellar/error_handling.rb
+++ b/lib/couchbase/protostellar/error_handling.rb
@@ -1,5 +1,19 @@
 # frozen_string_literal: true
 
+#  Copyright 2023. Couchbase, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 require "couchbase/errors"
 require "google/rpc/error_details_pb"
 

--- a/lib/couchbase/protostellar/error_handling.rb
+++ b/lib/couchbase/protostellar/error_handling.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require "couchbase/errors"
+require "google/rpc/error_details_pb"
+
+require_relative "request_behaviour"
+require_relative "retry/orchestrator"
+
+module Couchbase
+  module Protostellar
+    module ErrorHandling
+      TYPE_URL_PRECONDITION_FAILURE = "type.googleapis.com/google.rpc.PreconditionFailure"
+      TYPE_URL_RESOURCE_INFO = "type.googleapis.com/google.rpc.ResourceInfo"
+      TYPE_URL_ERROR_INFO = "type.googleapis.com/google.rpc.ErrorInfo"
+      TYPE_URL_BAD_REQUEST = "type.googleapis.com/google.rpc.BadRequest"
+
+      def self.handle_grpc_error(grpc_error, request)
+        request.context = {} if request.context.nil?
+        detail_block = {}
+
+        rpc_status = grpc_error.to_rpc_status
+        request.context[:grpc_error] = {type: grpc_error.class}
+        request.context[:grpc_error][:code] = rpc_status.code unless rpc_status.nil?
+
+        # Decode the detail block
+        rpc_status&.details&.each do |d|
+          type_url = d.type_url
+
+          if type_url == TYPE_URL_PRECONDITION_FAILURE
+            precondition_failure = Google::Rpc::PreconditionFailure.decode(d.value)
+            detail_block[:precondition_failure] = precondition_failure
+            context[:precondition_violations] = precondition_failure.violations.map do |v|
+              {
+                violation_type: v.type,
+                violation_subject: v.subject,
+                violation_description: v.description,
+              }
+            end
+          end
+
+          if type_url == TYPE_URL_RESOURCE_INFO
+            resource_info = Google::Rpc::ResourceInfo.decode(d.value)
+            detail_block[:resource_info] = resource_info
+            request.context[:resource_type] = resource_info.resource_type
+            request.context[:resource_name] = resource_info.resource_name
+          end
+
+          if type_url == TYPE_URL_ERROR_INFO
+            error_info = Google::Rpc::ErrorInfo.decode(d.value)
+            detail_block[:error_info] = error_info
+            request.context[:error_reason] = error_info.reason
+            request.context[:error_domain] = error_info.domain
+            request.context[:error_metadata] = error_info.metadata.to_h
+          end
+
+          if type_url == TYPE_URL_BAD_REQUEST
+            bad_request = Google::Rpc::BadRequest.decode(d.value)
+            detail_block[:bad_request] = bad_request
+            request.context[:field_violations] = bad_request.field_violations.map do |v|
+              {
+                field: v.field,
+                description: v.description,
+              }
+            end
+          end
+        end
+
+        case request.service
+        when :kv
+          handle_kv_error(grpc_error, detail_block, request)
+        when :query
+          handle_query_error(grpc_error, detail_block, request)
+        else
+          handle_generic_error(grpc_error, detail_block, request)
+        end
+      end
+
+      def self.handle_generic_error(grpc_error, detail_block, request)
+        case grpc_error
+        when GRPC::DeadlineExceeded
+          RequestBehaviour.fail(Couchbase::Error::Timeout.new(nil, request.context))
+        when GRPC::Cancelled
+          RequestBehaviour.fail(Couchbase::Error::RequestCanceled.new(nil, request.context))
+        when GRPC::Aborted
+          if detail_block[:error_info].reason == "CAS_MISMATCH" && detail_block[:resource_info].resource_type == "document"
+            RequestBehaviour.fail(Couchbase::Error::CasMismatch.new("CAS mismatch", request.context))
+          end
+        when GRPC::NotFound
+          case detail_block[:resource_info].resource_type
+          when "collection"
+            RequestBehaviour.fail(Couchbase::Error::CollectionNotFound.new("Collection not found", request.context))
+          when "bucket"
+            RequestBehaviour.fail(Couchbase::Error::BucketNotFound.new("Bucket not found", request.context))
+          when "scope"
+            RequestBehaviour.fail(Couchbase::Error::ScopeNotFound.new("Scope not found", request.context))
+          end
+        else
+          RequestBehaviour.fail(Couchbase::Error::CouchbaseError.new(nil, request.context))
+        end
+      end
+
+      def self.handle_kv_error(grpc_error, detail_block, request)
+        behaviour =
+          case grpc_error
+          when GRPC::NotFound
+            if detail_block[:resource_info].resource_type == "document"
+              RequestBehaviour.fail(Couchbase::Error::DocumentNotFound.new("Document not found", request.context))
+            end
+          when GRPC::AlreadyExists
+            if detail_block[:resource_info].resource_type == "document"
+              RequestBehaviour.fail(Couchbase::Error::DocumentExists.new("Document already exists", request.context))
+            end
+          when GRPC::FailedPrecondition
+            if detail_block[:precondition_failure].violations[0].type == "DOCUMENT_LOCKED"
+              Retry::Orchestrator.maybe_retry(request, Retry::Reason::KV_LOCKED)
+            end
+          end
+        if behaviour.nil?
+          handle_generic_error(grpc_error, detail_block, request)
+        else
+          behaviour
+        end
+      end
+
+      def self.handle_query_error(grpc_error, detail_block, request)
+        handle_generic_error(grpc_error, detail_block, request)
+      end
+    end
+  end
+end

--- a/lib/couchbase/protostellar/generated/admin/bucket.v1_services_pb.rb
+++ b/lib/couchbase/protostellar/generated/admin/bucket.v1_services_pb.rb
@@ -12,6 +12,7 @@ module Couchbase
           module V1
             module BucketAdmin
               class Service
+
                 include ::GRPC::GenericService
 
                 self.marshal_class_method = :encode

--- a/lib/couchbase/protostellar/generated/admin/collection.v1_services_pb.rb
+++ b/lib/couchbase/protostellar/generated/admin/collection.v1_services_pb.rb
@@ -12,20 +12,18 @@ module Couchbase
           module V1
             module CollectionAdmin
               class Service
+
                 include ::GRPC::GenericService
 
                 self.marshal_class_method = :encode
                 self.unmarshal_class_method = :decode
                 self.service_name = 'couchbase.admin.collection.v1.CollectionAdmin'
 
-                rpc :ListCollections, ::Couchbase::Protostellar::Generated::Admin::Collection::V1::ListCollectionsRequest,
-                    ::Couchbase::Protostellar::Generated::Admin::Collection::V1::ListCollectionsResponse
+                rpc :ListCollections, ::Couchbase::Protostellar::Generated::Admin::Collection::V1::ListCollectionsRequest, ::Couchbase::Protostellar::Generated::Admin::Collection::V1::ListCollectionsResponse
                 rpc :CreateScope, ::Couchbase::Protostellar::Generated::Admin::Collection::V1::CreateScopeRequest, ::Couchbase::Protostellar::Generated::Admin::Collection::V1::CreateScopeResponse
                 rpc :DeleteScope, ::Couchbase::Protostellar::Generated::Admin::Collection::V1::DeleteScopeRequest, ::Couchbase::Protostellar::Generated::Admin::Collection::V1::DeleteScopeResponse
-                rpc :CreateCollection, ::Couchbase::Protostellar::Generated::Admin::Collection::V1::CreateCollectionRequest,
-                    ::Couchbase::Protostellar::Generated::Admin::Collection::V1::CreateCollectionResponse
-                rpc :DeleteCollection, ::Couchbase::Protostellar::Generated::Admin::Collection::V1::DeleteCollectionRequest,
-                    ::Couchbase::Protostellar::Generated::Admin::Collection::V1::DeleteCollectionResponse
+                rpc :CreateCollection, ::Couchbase::Protostellar::Generated::Admin::Collection::V1::CreateCollectionRequest, ::Couchbase::Protostellar::Generated::Admin::Collection::V1::CreateCollectionResponse
+                rpc :DeleteCollection, ::Couchbase::Protostellar::Generated::Admin::Collection::V1::DeleteCollectionRequest, ::Couchbase::Protostellar::Generated::Admin::Collection::V1::DeleteCollectionResponse
               end
 
               Stub = Service.rpc_stub_class

--- a/lib/couchbase/protostellar/generated/analytics.v1_services_pb.rb
+++ b/lib/couchbase/protostellar/generated/analytics.v1_services_pb.rb
@@ -11,6 +11,7 @@ module Couchbase
         module V1
           module Analytics
             class Service
+
               include ::GRPC::GenericService
 
               self.marshal_class_method = :encode

--- a/lib/couchbase/protostellar/generated/internal/health.v1_services_pb.rb
+++ b/lib/couchbase/protostellar/generated/internal/health.v1_services_pb.rb
@@ -12,6 +12,7 @@ module Couchbase
           module V1
             module Health
               class Service
+
                 include ::GRPC::GenericService
 
                 self.marshal_class_method = :encode

--- a/lib/couchbase/protostellar/generated/internal/hooks.v1_services_pb.rb
+++ b/lib/couchbase/protostellar/generated/internal/hooks.v1_services_pb.rb
@@ -12,19 +12,17 @@ module Couchbase
           module V1
             module Hooks
               class Service
+
                 include ::GRPC::GenericService
 
                 self.marshal_class_method = :encode
                 self.unmarshal_class_method = :decode
                 self.service_name = 'couchbase.internal.hooks.v1.Hooks'
 
-                rpc :CreateHooksContext, ::Couchbase::Protostellar::Generated::Internal::Hooks::V1::CreateHooksContextRequest,
-                    ::Couchbase::Protostellar::Generated::Internal::Hooks::V1::CreateHooksContextResponse
-                rpc :DestroyHooksContext, ::Couchbase::Protostellar::Generated::Internal::Hooks::V1::DestroyHooksContextRequest,
-                    ::Couchbase::Protostellar::Generated::Internal::Hooks::V1::DestroyHooksContextResponse
+                rpc :CreateHooksContext, ::Couchbase::Protostellar::Generated::Internal::Hooks::V1::CreateHooksContextRequest, ::Couchbase::Protostellar::Generated::Internal::Hooks::V1::CreateHooksContextResponse
+                rpc :DestroyHooksContext, ::Couchbase::Protostellar::Generated::Internal::Hooks::V1::DestroyHooksContextRequest, ::Couchbase::Protostellar::Generated::Internal::Hooks::V1::DestroyHooksContextResponse
                 rpc :AddHooks, ::Couchbase::Protostellar::Generated::Internal::Hooks::V1::AddHooksRequest, ::Couchbase::Protostellar::Generated::Internal::Hooks::V1::AddHooksResponse
-                rpc :WatchBarrier, ::Couchbase::Protostellar::Generated::Internal::Hooks::V1::WatchBarrierRequest,
-                    stream(::Couchbase::Protostellar::Generated::Internal::Hooks::V1::WatchBarrierResponse)
+                rpc :WatchBarrier, ::Couchbase::Protostellar::Generated::Internal::Hooks::V1::WatchBarrierRequest, stream(::Couchbase::Protostellar::Generated::Internal::Hooks::V1::WatchBarrierResponse)
                 rpc :SignalBarrier, ::Couchbase::Protostellar::Generated::Internal::Hooks::V1::SignalBarrierRequest, ::Couchbase::Protostellar::Generated::Internal::Hooks::V1::SignalBarrierResponse
               end
 

--- a/lib/couchbase/protostellar/generated/kv.v1_services_pb.rb
+++ b/lib/couchbase/protostellar/generated/kv.v1_services_pb.rb
@@ -11,6 +11,7 @@ module Couchbase
         module V1
           module Kv
             class Service
+
               include ::GRPC::GenericService
 
               self.marshal_class_method = :encode

--- a/lib/couchbase/protostellar/generated/query.v1_services_pb.rb
+++ b/lib/couchbase/protostellar/generated/query.v1_services_pb.rb
@@ -11,6 +11,7 @@ module Couchbase
         module V1
           module Query
             class Service
+
               include ::GRPC::GenericService
 
               self.marshal_class_method = :encode

--- a/lib/couchbase/protostellar/generated/routing.v1_services_pb.rb
+++ b/lib/couchbase/protostellar/generated/routing.v1_services_pb.rb
@@ -11,6 +11,7 @@ module Couchbase
         module V1
           module Routing
             class Service
+
               include ::GRPC::GenericService
 
               self.marshal_class_method = :encode

--- a/lib/couchbase/protostellar/generated/search.v1_services_pb.rb
+++ b/lib/couchbase/protostellar/generated/search.v1_services_pb.rb
@@ -11,6 +11,7 @@ module Couchbase
         module V1
           module Search
             class Service
+
               include ::GRPC::GenericService
 
               self.marshal_class_method = :encode

--- a/lib/couchbase/protostellar/generated/transactions.v1_services_pb.rb
+++ b/lib/couchbase/protostellar/generated/transactions.v1_services_pb.rb
@@ -11,25 +11,20 @@ module Couchbase
         module V1
           module Transactions
             class Service
+
               include ::GRPC::GenericService
 
               self.marshal_class_method = :encode
               self.unmarshal_class_method = :decode
               self.service_name = 'couchbase.transactions.v1.Transactions'
 
-              rpc :TransactionBeginAttempt, ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionBeginAttemptRequest,
-                  ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionBeginAttemptResponse
-              rpc :TransactionCommit, ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionCommitRequest,
-                  ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionCommitResponse
-              rpc :TransactionRollback, ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionRollbackRequest,
-                  ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionRollbackResponse
+              rpc :TransactionBeginAttempt, ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionBeginAttemptRequest, ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionBeginAttemptResponse
+              rpc :TransactionCommit, ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionCommitRequest, ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionCommitResponse
+              rpc :TransactionRollback, ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionRollbackRequest, ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionRollbackResponse
               rpc :TransactionGet, ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionGetRequest, ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionGetResponse
-              rpc :TransactionInsert, ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionInsertRequest,
-                  ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionInsertResponse
-              rpc :TransactionReplace, ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionReplaceRequest,
-                  ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionReplaceResponse
-              rpc :TransactionRemove, ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionRemoveRequest,
-                  ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionRemoveResponse
+              rpc :TransactionInsert, ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionInsertRequest, ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionInsertResponse
+              rpc :TransactionReplace, ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionReplaceRequest, ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionReplaceResponse
+              rpc :TransactionRemove, ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionRemoveRequest, ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionRemoveResponse
             end
 
             Stub = Service.rpc_stub_class

--- a/lib/couchbase/protostellar/generated/view.v1_services_pb.rb
+++ b/lib/couchbase/protostellar/generated/view.v1_services_pb.rb
@@ -11,6 +11,7 @@ module Couchbase
         module V1
           module View
             class Service
+
               include ::GRPC::GenericService
 
               self.marshal_class_method = :encode

--- a/lib/couchbase/protostellar/request.rb
+++ b/lib/couchbase/protostellar/request.rb
@@ -1,6 +1,19 @@
 # frozen_string_literal: true
 
-require "set"
+#  Copyright 2023. Couchbase, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 require "couchbase/utils/time"
 require_relative "retry/strategies/best_effort"
 

--- a/lib/couchbase/protostellar/request.rb
+++ b/lib/couchbase/protostellar/request.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "set"
+require "couchbase/utils/time"
+require_relative "retry/strategies/best_effort"
+
+module Couchbase
+  module Protostellar
+    class Request
+      attr_reader :service
+      attr_reader :rpc
+      attr_reader :timeout
+      attr_reader :proto_request
+      attr_reader :idempotent
+      attr_reader :retry_attempts
+      attr_reader :retry_reasons
+      attr_reader :retry_strategy
+      attr_accessor :context
+
+      def initialize(
+        service:,
+        rpc:,
+        proto_request:,
+        timeout:,
+        retry_strategy: Retry::Strategies::BestEffort::DEFAULT,
+        idempotent: false
+      )
+        @service = service
+        @rpc = rpc
+        @timeout = timeout
+        @deadline = nil
+        @proto_request = proto_request
+        @idempotent = idempotent
+        @retry_attempts = 0
+        @retry_reasons = Set.new
+        @retry_strategy = retry_strategy
+      end
+
+      def deadline
+        if @deadline.nil?
+          timeout_secs = 0.001 * Utils::Time.extract_duration(@timeout)
+          @deadline = Time.now + timeout_secs
+        end
+        @deadline
+      end
+
+      def add_retry_attempt(reason)
+        @retry_reasons.add(reason)
+        @retry_attempts += 1
+      end
+    end
+  end
+end

--- a/lib/couchbase/protostellar/request_behaviour.rb
+++ b/lib/couchbase/protostellar/request_behaviour.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Couchbase
+  module Protostellar
+    class RequestBehaviour
+      attr_reader :retry_duration
+      attr_reader :error
+
+      def initialize(retry_duration: nil, error: nil)
+        @retry_duration = retry_duration
+        @error = error
+      end
+
+      def self.fail(error)
+        RequestBehaviour.new(error: error)
+      end
+
+      def self.retry(retry_duration)
+        RequestBehaviour.new(retry_duration: retry_duration)
+      end
+    end
+  end
+end

--- a/lib/couchbase/protostellar/request_behaviour.rb
+++ b/lib/couchbase/protostellar/request_behaviour.rb
@@ -1,5 +1,19 @@
 # frozen_string_literal: true
 
+#  Copyright 2023. Couchbase, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 module Couchbase
   module Protostellar
     class RequestBehaviour

--- a/lib/couchbase/protostellar/request_generator/kv.rb
+++ b/lib/couchbase/protostellar/request_generator/kv.rb
@@ -18,6 +18,8 @@ require "couchbase/json_transcoder"
 require "couchbase/utils/time"
 
 require "couchbase/protostellar/generated/kv.v1_pb"
+require "couchbase/protostellar/request"
+require "couchbase/protostellar/timeout_defaults"
 
 require "google/protobuf/well_known_types"
 
@@ -28,11 +30,13 @@ module Couchbase
         attr_reader :bucket_name
         attr_reader :scope_name
         attr_reader :collection_name
+        attr_reader :default_timeout
 
-        def initialize(bucket_name, scope_name, collection_name)
+        def initialize(bucket_name, scope_name, collection_name, default_timeout = nil)
           @bucket_name = bucket_name
           @scope_name = scope_name
           @collection_name = collection_name
+          @default_timeout = default_timeout.nil? ? TimeoutDefaults::KEY_VALUE : default_timeout
         end
 
         def location
@@ -43,27 +47,30 @@ module Couchbase
           }
         end
 
-        def get_request(id, _options)
+        def get_request(id, options)
           proto_opts = {}
 
-          Generated::KV::V1::GetRequest.new(
+          proto_req = Generated::KV::V1::GetRequest.new(
             key: id,
             **location,
             **proto_opts
           )
+
+          create_kv_request(proto_req, :get, options, true)
         end
 
         def get_and_touch_request(id, expiry, _options)
           proto_opts = {}
           expiry = get_expiry(expiry)
 
-          Generated::KV::V1::GetAndTouchRequest.new(
+          proto_req = Generated::KV::V1::GetAndTouchRequest.new(
             **location,
             key: id,
             expiry: expiry,
-            **options.to_request,
             **proto_opts
           )
+
+          create_kv_request(proto_req, :get_and_touch, options)
         end
 
         def upsert_request(id, content, options)
@@ -73,14 +80,16 @@ module Couchbase
             content_type: get_content_type(options),
           }
           proto_opts[:durability_level] = get_durability_level(options) unless options.durability_level == :none
-          proto_opts[:expiry] = get_expiry(options) unless options.preserve_expiry
+          proto_opts[:expiry] = get_expiry(options) unless options.preserve_expiry  # TODO Figure out expiry
 
-          Generated::KV::V1::UpsertRequest.new(
+          proto_req = Generated::KV::V1::UpsertRequest.new(
             key: id,
             content: encoded,
             **location,
             **proto_opts
           )
+
+          create_kv_request(proto_req, :upsert, options)
         end
 
         def insert_request(id, content, options)
@@ -93,12 +102,14 @@ module Couchbase
           proto_opts[:durability_level] = get_durability_level(options) unless options.durability_level == :none
           proto_opts[:expiry] = get_expiry(options) unless options.expiry.nil?
 
-          Generated::KV::V1::InsertRequest.new(
+          proto_req = Generated::KV::V1::InsertRequest.new(
             key: id,
             content: encoded,
             **location,
             **proto_opts
           )
+
+          create_kv_request(proto_req, :insert, options)
         end
 
         def replace_request(id, content, options)
@@ -112,12 +123,14 @@ module Couchbase
           proto_opts[:durability_level] = get_durability_level(options) unless options.durability_level == :none
           proto_opts[:expiry] = get_expiry(options) unless options.preserve_expiry
 
-          Generated::KV::V1::ReplaceRequest.new(
+          proto_req = Generated::KV::V1::ReplaceRequest.new(
             key: id,
             content: encoded,
             **location,
             **proto_opts
           )
+
+          create_kv_request(proto_req, :replace, options)
         end
 
         def remove_request(id, options)
@@ -126,21 +139,25 @@ module Couchbase
           proto_opts[:cas] = options.cas unless options.cas.nil?
           proto_opts[:durability_level] = get_durability_level(options) unless options.durability_level == :none
 
-          Generated::KV::V1::RemoveRequest.new(
+          proto_req = Generated::KV::V1::RemoveRequest.new(
             key: id,
             **location,
             **proto_opts
           )
+
+          create_kv_request(proto_req, :remove, options)
         end
 
-        def exists_request(id, _options)
+        def exists_request(id, options)
           proto_opts = {}
 
-          Generated::KV::V1::ExistsRequest.new(
+          proto_req = Generated::KV::V1::ExistsRequest.new(
             key: id,
             **proto_opts,
             **location
           )
+
+          create_kv_request(proto_req, :exists, options)
         end
 
         def mutate_in_request(id, specs, options)
@@ -151,12 +168,14 @@ module Couchbase
           }
           proto_opts[:cas] = options.cas unless options.cas.nil?
 
-          Generated::KV::V1::MutateInRequest.new(
+          proto_req = Generated::KV::V1::MutateInRequest.new(
             key: id,
             **location,
             specs: specs.map { |s| get_mutate_in_spec(s) },
             **proto_opts
           )
+
+          create_kv_request(proto_req, :mutate_in, options)
         end
 
         def lookup_in_request(id, specs, options)
@@ -164,15 +183,27 @@ module Couchbase
             flags: get_lookup_in_flags(options),
           }
 
-          Generated::KV::V1::LookupInRequest.new(
+          proto_req = Generated::KV::V1::LookupInRequest.new(
             key: id,
             **location,
             specs: specs.map { |s| get_lookup_in_spec(s) },
             **proto_opts
           )
+
+          create_kv_request(proto_req, :lookup_in, options, true)
         end
 
         private
+
+        def create_kv_request(proto_request, rpc, options, idempotent = false)
+          Request.new(
+            service: :kv,
+            rpc: rpc,
+            proto_request: proto_request,
+            timeout: get_timeout(options),
+            idempotent: idempotent
+          )
+        end
 
         def get_expiry(options_or_expiry)
           if options_or_expiry.respond_to? :expiry
@@ -279,6 +310,14 @@ module Couchbase
 
         def get_mutate_in_store_semantic(options)
           options.store_semantics.upcase
+        end
+
+        def get_timeout(options)
+          if options.timeout.nil?
+            @default_timeout
+          else
+            options.timeout
+          end
         end
       end
     end

--- a/lib/couchbase/protostellar/request_generator/kv.rb
+++ b/lib/couchbase/protostellar/request_generator/kv.rb
@@ -36,6 +36,8 @@ module Couchbase
           @bucket_name = bucket_name
           @scope_name = scope_name
           @collection_name = collection_name
+
+          # TODO: Use the KV timeout from the cluster's options
           @default_timeout = default_timeout.nil? ? TimeoutDefaults::KEY_VALUE : default_timeout
         end
 

--- a/lib/couchbase/protostellar/response_converter.rb
+++ b/lib/couchbase/protostellar/response_converter.rb
@@ -14,6 +14,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+require_relative "response_converter/kv"
+require_relative "response_converter/query"
+
 module Couchbase
   module Protostellar
     module ResponseConverter

--- a/lib/couchbase/protostellar/retry.rb
+++ b/lib/couchbase/protostellar/retry.rb
@@ -1,5 +1,19 @@
 # frozen_string_literal: true
 
+#  Copyright 2023. Couchbase, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 require_relative "retry/strategies"
 require_relative "retry/orchestrator"
 require_relative "retry/reason"

--- a/lib/couchbase/protostellar/retry.rb
+++ b/lib/couchbase/protostellar/retry.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require_relative "retry/strategies"
+require_relative "retry/orchestrator"
+require_relative "retry/reason"
+require_relative "retry/action"
+
+module Couchbase
+  module Protostellar
+    module Retry
+    end
+  end
+end

--- a/lib/couchbase/protostellar/retry/action.rb
+++ b/lib/couchbase/protostellar/retry/action.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright 2023-Present. Couchbase, Inc.
+#  Copyright 2023-Present Couchbase, Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -14,12 +14,24 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-require_relative "request_generator/kv"
-require_relative "request_generator/query"
-
 module Couchbase
   module Protostellar
-    module RequestGenerator
+    module Retry
+      class Action
+        attr_reader :duration
+
+        def initialize(duration)
+          @duration = duration
+        end
+
+        def self.with_duration(duration)
+          Action.new(duration)
+        end
+
+        def self.no_retry
+          Action.new(nil)
+        end
+      end
     end
   end
 end

--- a/lib/couchbase/protostellar/retry/orchestrator.rb
+++ b/lib/couchbase/protostellar/retry/orchestrator.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require_relative '../request_behaviour'
+require_relative 'action'
+require 'couchbase/errors'
+require 'couchbase/logger'
+
+module Couchbase
+  module Protostellar
+    module Retry
+      class Orchestrator
+        def self.maybe_retry(request, reason)
+          if reason.always_retry
+            retry_duration = get_controlled_backoff(request)
+            request.add_retry_attempt(reason)
+            # TODO: Log retry
+            RequestBehaviour.retry(retry_duration)
+          else
+            retry_action = request.retry_strategy.retry_after(request, reason)
+            duration = retry_action.duration
+            if duration.nil?
+              # TODO: Log not retried
+              RequestBehaviour.fail(Error::RequestCanceled.new)
+            else
+              request.add_retry_attempt(reason)
+              # TODO: Log retry
+              RequestBehaviour.retry(duration)
+            end
+          end
+        end
+
+        def self.get_controlled_backoff(request)
+          case request.retry_attempts
+          when 0 then 1
+          when 1 then 10
+          when 2 then 50
+          when 3 then 100
+          when 4 then 500
+          else 1000
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/couchbase/protostellar/retry/orchestrator.rb
+++ b/lib/couchbase/protostellar/retry/orchestrator.rb
@@ -34,7 +34,7 @@ module Couchbase
             duration = retry_action.duration
             if duration.nil?
               # TODO: Log not retried
-              RequestBehaviour.fail(Error::RequestCanceled.new)
+              RequestBehaviour.fail(Couchbase::Error::RequestCanceled.new)
             else
               request.add_retry_attempt(reason)
               # TODO: Log retry

--- a/lib/couchbase/protostellar/retry/orchestrator.rb
+++ b/lib/couchbase/protostellar/retry/orchestrator.rb
@@ -1,5 +1,19 @@
 # frozen_string_literal: true
 
+#  Copyright 2023. Couchbase, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 require_relative '../request_behaviour'
 require_relative 'action'
 require 'couchbase/errors'

--- a/lib/couchbase/protostellar/retry/reason.rb
+++ b/lib/couchbase/protostellar/retry/reason.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+#  Copyright 2023-Present Couchbase, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+module Couchbase
+  module Protostellar
+    module Retry
+      class Reason
+        attr_reader :allows_non_idempotent_retry
+        attr_reader :always_retry
+
+        def initialize(allows_non_idempotent_retry, always_retry)
+          @allows_non_idempotent_retry = allows_non_idempotent_retry
+          @always_retry = always_retry
+        end
+
+        UNKNOWN = Reason.new(false, false).freeze
+        SOCKET_NOT_AVAILABLE = Reason.new(true, false).freeze
+        SERVICE_NOT_AVAILABLE = Reason.new(true, false).freeze
+        NODE_NOT_AVAILABLE = Reason.new(true, false).freeze
+        KV_NOT_MY_VBUCKET = Reason.new(true, true).freeze
+        KV_COLLECTION_OUTDATED = Reason.new(true, true).freeze
+        KV_ERROR_MAP_RETRY_INDICATED = Reason.new(true, false).freeze
+        KV_LOCKED = Reason.new(true, false).freeze
+        KV_TEMPORARY_FAILURE = Reason.new(true, false).freeze
+        KV_SYNC_WRITE_IN_PROGRESS = Reason.new(true, false).freeze
+        KV_SYNC_WRITE_RE_COMMIT_IN_PROGRESS = Reason.new(true, false).freeze
+        SERVICE_RESPONSE_CODE_INDICATED = Reason.new(true, false).freeze
+        SOCKET_CLOSED_WHILE_IN_FLIGHT = Reason.new(false, false).freeze
+        CIRCUIT_BREAKER_OPEN = Reason.new(true, false).freeze
+        QUERY_PREPARED_STATEMENT_FAILURE = Reason.new(true, false).freeze
+        QUERY_INDEX_NOT_FOUND = Reason.new(true, false).freeze
+        ANALYTICS_TEMPORARY_FAILURE = Reason.new(true, false).freeze
+        SEARCH_TOO_MANY_REQUESTS = Reason.new(true, false).freeze
+        VIEWS_TEMPORARY_FAILURE = Reason.new(true, false).freeze
+        VIEWS_NO_ACTIVE_PARTITION = Reason.new(true, true).freeze
+      end
+    end
+  end
+end

--- a/lib/couchbase/protostellar/retry/reason.rb
+++ b/lib/couchbase/protostellar/retry/reason.rb
@@ -20,32 +20,43 @@ module Couchbase
       class Reason
         attr_reader :allows_non_idempotent_retry
         attr_reader :always_retry
+        attr_reader :name
 
-        def initialize(allows_non_idempotent_retry, always_retry)
+        def self.reason(name, allows_non_idempotent_retry:, always_retry:)
+          const_set(
+            name,
+            new(name: name,
+                allows_non_idempotent_retry: allows_non_idempotent_retry,
+                always_retry: always_retry).freeze
+          )
+        end
+
+        def initialize(name:, allows_non_idempotent_retry:, always_retry:)
+          @name = name
           @allows_non_idempotent_retry = allows_non_idempotent_retry
           @always_retry = always_retry
         end
 
-        UNKNOWN = Reason.new(false, false).freeze
-        SOCKET_NOT_AVAILABLE = Reason.new(true, false).freeze
-        SERVICE_NOT_AVAILABLE = Reason.new(true, false).freeze
-        NODE_NOT_AVAILABLE = Reason.new(true, false).freeze
-        KV_NOT_MY_VBUCKET = Reason.new(true, true).freeze
-        KV_COLLECTION_OUTDATED = Reason.new(true, true).freeze
-        KV_ERROR_MAP_RETRY_INDICATED = Reason.new(true, false).freeze
-        KV_LOCKED = Reason.new(true, false).freeze
-        KV_TEMPORARY_FAILURE = Reason.new(true, false).freeze
-        KV_SYNC_WRITE_IN_PROGRESS = Reason.new(true, false).freeze
-        KV_SYNC_WRITE_RE_COMMIT_IN_PROGRESS = Reason.new(true, false).freeze
-        SERVICE_RESPONSE_CODE_INDICATED = Reason.new(true, false).freeze
-        SOCKET_CLOSED_WHILE_IN_FLIGHT = Reason.new(false, false).freeze
-        CIRCUIT_BREAKER_OPEN = Reason.new(true, false).freeze
-        QUERY_PREPARED_STATEMENT_FAILURE = Reason.new(true, false).freeze
-        QUERY_INDEX_NOT_FOUND = Reason.new(true, false).freeze
-        ANALYTICS_TEMPORARY_FAILURE = Reason.new(true, false).freeze
-        SEARCH_TOO_MANY_REQUESTS = Reason.new(true, false).freeze
-        VIEWS_TEMPORARY_FAILURE = Reason.new(true, false).freeze
-        VIEWS_NO_ACTIVE_PARTITION = Reason.new(true, true).freeze
+        reason :UNKNOWN, allows_non_idempotent_retry: false, always_retry: false
+        reason :SOCKET_NOT_AVAILABLE, allows_non_idempotent_retry: true, always_retry: false
+        reason :SERVICE_NOT_AVAILABLE, allows_non_idempotent_retry: true, always_retry: false
+        reason :NODE_NOT_AVAILABLE, allows_non_idempotent_retry: true, always_retry: false
+        reason :KV_NOT_MY_VBUCKET, allows_non_idempotent_retry: true, always_retry: true
+        reason :KV_COLLECTION_OUTDATED, allows_non_idempotent_retry: true, always_retry: true
+        reason :KV_ERROR_MAP_RETRY_INDICATED, allows_non_idempotent_retry: true, always_retry: false
+        reason :KV_LOCKED, allows_non_idempotent_retry: true, always_retry: false
+        reason :KV_TEMPORARY_FAILURE, allows_non_idempotent_retry: true, always_retry: false
+        reason :KV_SYNC_WRITE_IN_PROGRESS, allows_non_idempotent_retry: true, always_retry: false
+        reason :KV_SYNC_WRITE_RE_COMMIT_IN_PROGRESS, allows_non_idempotent_retry: true, always_retry: false
+        reason :SERVICE_RESPONSE_CODE_INDICATED, allows_non_idempotent_retry: true, always_retry: false
+        reason :SOCKET_CLOSED_WHILE_IN_FLIGHT, allows_non_idempotent_retry: false, always_retry: false
+        reason :CIRCUIT_BREAKER_OPEN, allows_non_idempotent_retry: true, always_retry: false
+        reason :QUERY_PREPARED_STATEMENT_FAILURE, allows_non_idempotent_retry: true, always_retry: false
+        reason :QUERY_INDEX_NOT_FOUND, allows_non_idempotent_retry: true, always_retry: false
+        reason :ANALYTICS_TEMPORARY_FAILURE, allows_non_idempotent_retry: true, always_retry: false
+        reason :SEARCH_TOO_MANY_REQUESTS, allows_non_idempotent_retry: true, always_retry: false
+        reason :VIEWS_TEMPORARY_FAILURE, allows_non_idempotent_retry: true, always_retry: false
+        reason :VIEWS_NO_ACTIVE_PARTITION, allows_non_idempotent_retry: true, always_retry: true
       end
     end
   end

--- a/lib/couchbase/protostellar/retry/strategies.rb
+++ b/lib/couchbase/protostellar/retry/strategies.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative "strategies/best_effort"
+
+module Couchbase
+  module Protostellar
+    module Retry
+      module Strategies
+      end
+    end
+  end
+end

--- a/lib/couchbase/protostellar/retry/strategies.rb
+++ b/lib/couchbase/protostellar/retry/strategies.rb
@@ -1,5 +1,19 @@
 # frozen_string_literal: true
 
+#  Copyright 2023. Couchbase, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 require_relative "strategies/best_effort"
 
 module Couchbase

--- a/lib/couchbase/protostellar/retry/strategies/best_effort.rb
+++ b/lib/couchbase/protostellar/retry/strategies/best_effort.rb
@@ -1,5 +1,19 @@
 # frozen_string_literal: true
 
+#  Copyright 2023. Couchbase, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 module Couchbase
   module Protostellar
     module Retry

--- a/lib/couchbase/protostellar/retry/strategies/best_effort.rb
+++ b/lib/couchbase/protostellar/retry/strategies/best_effort.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Couchbase
+  module Protostellar
+    module Retry
+      module Strategies
+        class BestEffort
+          attr_reader :backoff_calculator
+
+          def initialize(backoff_calculator = nil)
+            # The default backoff calculator starts with a 1 millisecond backoff and doubles it after each retry
+            # attempt, up to a maximum of 50 milliseconds
+            @backoff_calculator =
+              if backoff_calculator.nil?
+                lambda { |retry_attempt_count| [2**retry_attempt_count, 50].min }
+              else
+                backoff_calculator
+              end
+          end
+
+          def retry_after(request, reason)
+            if request.idempotent || reason.allows_non_idempotent_retry
+              backoff = @backoff_calculator.call(request.retry_attempts)
+              Retry::Action.with_duration(backoff)
+            else
+              Retry::Action.no_retry
+            end
+          end
+
+          DEFAULT = BestEffort.new.freeze
+        end
+      end
+    end
+  end
+end

--- a/lib/couchbase/protostellar/timeout_defaults.rb
+++ b/lib/couchbase/protostellar/timeout_defaults.rb
@@ -1,5 +1,19 @@
 # frozen_string_literal: true
 
+#  Copyright 2023. Couchbase, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 module Couchbase
   module Protostellar
     module TimeoutDefaults

--- a/lib/couchbase/protostellar/timeout_defaults.rb
+++ b/lib/couchbase/protostellar/timeout_defaults.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Couchbase
+  module Protostellar
+    module TimeoutDefaults
+      KEY_VALUE = 2_500
+      VIEW = 75_000
+      QUERY = 75_000
+      ANALYTICS = 75_000
+      SEARCH = 75_000
+      MANAGEMENT = 75_000
+    end
+  end
+end

--- a/sig/couchbase/protostellar/client.rbs
+++ b/sig/couchbase/protostellar/client.rbs
@@ -24,6 +24,9 @@ module Couchbase
       @view_stub: Object
 
       def initialize: (String host, untyped credentials, untyped channel_args) -> void
+      def stub: (Symbol) -> untyped
+      def send_request: (Request) -> untyped
+
 
       def kv: () -> untyped
 

--- a/sig/couchbase/protostellar/cluster.rbs
+++ b/sig/couchbase/protostellar/cluster.rbs
@@ -15,11 +15,14 @@
 module Couchbase
   module Protostellar
     class Cluster
-      @client: Client
+      attr_reader client: Client
+      @query_request_generator: RequestGenerator::Query
+
+      def self.connect: (String, untyped) -> untyped
 
       def initialize: (untyped connection_string, ?untyped options) -> void
 
-      def close: () -> void
+      def disconnect: () -> void
 
       def bucket: (String name) -> Bucket
 

--- a/sig/couchbase/protostellar/error_handling.rbs
+++ b/sig/couchbase/protostellar/error_handling.rbs
@@ -1,3 +1,17 @@
+#  Copyright 2023. Couchbase, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 module Couchbase
   module Protostellar
     class ErrorHandling

--- a/sig/couchbase/protostellar/error_handling.rbs
+++ b/sig/couchbase/protostellar/error_handling.rbs
@@ -1,0 +1,15 @@
+module Couchbase
+  module Protostellar
+    class ErrorHandling
+      TYPE_URL_PRECONDITION_FAILURE: String
+      TYPE_URL_RESOURCE_INFO: String
+      TYPE_URL_ERROR_INFO: String
+      TYPE_URL_BAD_REQUEST: String
+
+      def self.handle_grpc_error: (untyped, Request) -> RequestBehaviour
+      def self.handle_generic_error: (untyped, Hash[Symbol, any], Request) -> RequestBehaviour
+      def self.handle_kv_error: (untyped, Hash[Symbol, any], Request) -> RequestBehaviour
+      def self.handle_query_error: (untyped, Hash[Symbol, any], Request) -> RequestBehaviour
+    end
+  end
+end

--- a/sig/couchbase/protostellar/interfaces.rbs
+++ b/sig/couchbase/protostellar/interfaces.rbs
@@ -33,5 +33,9 @@ module Couchbase
     interface _CanToJson
       def to_json: () -> String
     end
+
+    interface _RetryStrategy
+      def retry_after: (Request, Retry::Reason) -> Retry::Action
+    end
   end
 end

--- a/sig/couchbase/protostellar/request.rbs
+++ b/sig/couchbase/protostellar/request.rbs
@@ -1,0 +1,45 @@
+#  Copyright 2023-Present Couchbase, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+module Couchbase
+  module Protostellar
+    class Request
+      type protostellar_service = :analytics | :kv | :query | :routing | :search | :transactions | :view
+
+      attr_reader service: protostellar_service
+      attr_reader rpc: Symbol
+      attr_reader timeout: (Integer | _CanInMilliseconds)?
+      attr_reader proto_request: untyped
+      attr_reader idempotent: bool
+      attr_reader retry_attempts: Integer
+      attr_reader retry_reasons: Set[untyped]
+      attr_reader retry_strategy: _RetryStrategy
+      attr_accessor context: Hash[Symbol, any]
+      @deadline: untyped
+
+      def initialize: (
+          service: protostellar_service,
+          rpc: Symbol,
+          timeout: Integer | _CanInMilliseconds,
+          proto_request: untyped,
+          retry_strategy: _RetryStrategy,
+          idempotent: bool
+        ) -> void
+
+      def deadline: () -> untyped
+
+      def add_retry_attempt: (Retry::Reason) -> void
+    end
+  end
+end

--- a/sig/couchbase/protostellar/request_behaviour.rbs
+++ b/sig/couchbase/protostellar/request_behaviour.rbs
@@ -1,0 +1,12 @@
+module Couchbase
+  module Protostellar
+    class RequestBehaviour
+      attr_reader retry_duration: Integer?
+      attr_reader error: StandardError?
+
+      def initialize: (retry_duration: Integer?, error: StandardError?) -> void
+      def self.fail: () -> RequestBehaviour
+      def self.retry: (Integer) -> RequestBehaviour
+    end
+  end
+end

--- a/sig/couchbase/protostellar/request_behaviour.rbs
+++ b/sig/couchbase/protostellar/request_behaviour.rbs
@@ -1,3 +1,17 @@
+#  Copyright 2023. Couchbase, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 module Couchbase
   module Protostellar
     class RequestBehaviour

--- a/sig/couchbase/protostellar/request_generator.rbs
+++ b/sig/couchbase/protostellar/request_generator.rbs
@@ -1,3 +1,17 @@
+#  Copyright 2023. Couchbase, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 module Couchbase
   module Protostellar
     module RequestGenerator

--- a/sig/couchbase/protostellar/request_generator/kv.rbs
+++ b/sig/couchbase/protostellar/request_generator/kv.rbs
@@ -2,6 +2,42 @@ module Couchbase
   module Protostellar
     module RequestGenerator
       class KV
+        attr_reader bucket_name: String
+        attr_reader scope_name: String
+        attr_reader collection_name: String
+        attr_reader default_timeout: _CanInMilliseconds | Integer
+
+        def initialize: (String, String, String, (_CanInMilliseconds | Integer)?) -> void
+
+        def location: () -> Hash[Symbol, String]
+
+        def get_request: (String, untyped) -> untyped
+        def get_and_touch_request: (String, (_CanInSeconds | Time | Integer), untyped) -> untyped
+        def upsert_request: (String, Object, untyped) -> untyped
+        def remove_request: (String, untyped) -> untyped
+        def insert_request: (String, Object, untyped) -> untyped
+        def replace_request: (String, Object, untyped) -> untyped
+        def exists_request: (String, untyped) -> untyped
+        def mutate_in_request: (String, Array[untyped], untyped) -> untyped
+        def lookup_in_request: (String, Array[untyped], untyped) -> untyped
+
+        private
+
+        def create_kv_request: (untyped, Symbol, untyped) -> untyped
+
+        def get_expiry: (untyped) -> untyped
+        def get_content_type: (untyped) -> Symbol
+        def get_durability_level: (untyped) -> Symbol?
+        def get_lookup_in_spec: (untyped) -> untyped
+        def get_lookup_in_operation: (untyped) -> untyped
+        def get_lookup_in_spec_flags: (untyped) -> untyped
+        def get_lookup_in_flags: (untyped) -> untyped
+        def get_mutate_in_spec: (untyped) -> untyped
+        def get_mutate_in_operation: (untyped) -> Symbol
+        def get_mutate_in_spec_flags: (untyped) -> untyped
+        def get_mutate_in_flags: (untyped) -> untyped
+        def get_mutate_in_store_semantic: (untyped) -> Symbol
+        def get_timeout: (untyped) -> (_CanInMilliseconds | Integer)
       end
     end
   end

--- a/sig/couchbase/protostellar/request_generator/query.rbs
+++ b/sig/couchbase/protostellar/request_generator/query.rbs
@@ -2,6 +2,23 @@ module Couchbase
   module Protostellar
     module RequestGenerator
       class Query
+        attr_reader bucket_name: String
+        attr_reader scope_name: String
+        attr_reader default_timeout: _CanInMilliseconds | Integer
+
+        def initialize: (
+            bucket_name: String?,
+            scope_name: String?,
+            default_timeout: (_CanInMilliseconds | Integer)?
+          ) -> void
+
+        def query_request: (String, untyped) -> untyped
+
+        private
+
+        def create_query_request: (untyped, Symbol, untyped) -> untyped
+        def create_tuning_options: (untyped) -> untyped
+        def get_timeout: (untyped) -> (_CanInMilliseconds | Integer)
       end
     end
   end

--- a/sig/couchbase/protostellar/response_converter.rbs
+++ b/sig/couchbase/protostellar/response_converter.rbs
@@ -1,3 +1,17 @@
+#  Copyright 2023. Couchbase, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 module Couchbase
   module Protostellar
     module ResponseConverter

--- a/sig/couchbase/protostellar/retry.rbs
+++ b/sig/couchbase/protostellar/retry.rbs
@@ -1,0 +1,6 @@
+module Couchbase
+  module Protostellar
+    module Retry
+    end
+  end
+end

--- a/sig/couchbase/protostellar/retry.rbs
+++ b/sig/couchbase/protostellar/retry.rbs
@@ -1,3 +1,17 @@
+#  Copyright 2023. Couchbase, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 module Couchbase
   module Protostellar
     module Retry

--- a/sig/couchbase/protostellar/retry/action.rbs
+++ b/sig/couchbase/protostellar/retry/action.rbs
@@ -1,0 +1,14 @@
+module Couchbase
+  module Protostellar
+    module Retry
+      class Action
+        attr_reader duration: Integer?
+
+        def initialize: (Integer?) -> void
+
+        def self.with_duration: (Integer) -> Action
+        def self.no_retry: () -> Action
+      end
+    end
+  end
+end

--- a/sig/couchbase/protostellar/retry/action.rbs
+++ b/sig/couchbase/protostellar/retry/action.rbs
@@ -1,3 +1,17 @@
+#  Copyright 2023. Couchbase, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 module Couchbase
   module Protostellar
     module Retry

--- a/sig/couchbase/protostellar/retry/orchestrator.rbs
+++ b/sig/couchbase/protostellar/retry/orchestrator.rbs
@@ -1,3 +1,17 @@
+#  Copyright 2023. Couchbase, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 module Couchbase
   module Protostellar
     module Retry

--- a/sig/couchbase/protostellar/retry/orchestrator.rbs
+++ b/sig/couchbase/protostellar/retry/orchestrator.rbs
@@ -1,0 +1,10 @@
+module Couchbase
+  module Protostellar
+    module Retry
+      class Orchestrator
+        def self.maybe_retry: (Request, Reason) -> void
+        def self.get_controlled_backoff: (Request) -> Integer
+      end
+    end
+  end
+end

--- a/sig/couchbase/protostellar/retry/reason.rbs
+++ b/sig/couchbase/protostellar/retry/reason.rbs
@@ -1,0 +1,33 @@
+module Couchbase
+  module Protostellar
+    module Retry
+      class Reason
+        attr_reader allows_non_idempotent_retry: bool
+        attr_reader always_retry: bool
+
+        def initialize: (bool, bool) -> void
+
+        UNKNOWN: Reason
+        SOCKET_NOT_AVAILABLE: Reason
+        SERVICE_NOT_AVAILABLE: Reason
+        NODE_NOT_AVAILABLE: Reason
+        KV_NOT_MY_VBUCKET: Reason
+        KV_COLLECTION_OUTDATED: Reason
+        KV_ERROR_MAP_RETRY_INDICATED: Reason
+        KV_LOCKED: Reason
+        KV_TEMPORARY_FAILURE: Reason
+        KV_SYNC_WRITE_IN_PROGRESS: Reason
+        KV_SYNC_WRITE_RE_COMMIT_IN_PROGRESS: Reason
+        SERVICE_RESPONSE_CODE_INDICATED: Reason
+        SOCKET_CLOSED_WHILE_IN_FLIGHT: Reason
+        CIRCUIT_BREAKER_OPEN: Reason
+        QUERY_PREPARED_STATEMENT_FAILURE: Reason
+        QUERY_INDEX_NOT_FOUND: Reason
+        ANALYTICS_TEMPORARY_FAILURE: Reason
+        SEARCH_TOO_MANY_REQUESTS: Reason
+        VIEWS_TEMPORARY_FAILURE: Reason
+        VIEWS_NO_ACTIVE_PARTITION: Reason
+      end
+    end
+  end
+end

--- a/sig/couchbase/protostellar/retry/reason.rbs
+++ b/sig/couchbase/protostellar/retry/reason.rbs
@@ -1,3 +1,17 @@
+#  Copyright 2023. Couchbase, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 module Couchbase
   module Protostellar
     module Retry

--- a/sig/couchbase/protostellar/retry/reason.rbs
+++ b/sig/couchbase/protostellar/retry/reason.rbs
@@ -16,10 +16,12 @@ module Couchbase
   module Protostellar
     module Retry
       class Reason
+        attr_reader name: Symbol
         attr_reader allows_non_idempotent_retry: bool
         attr_reader always_retry: bool
 
-        def initialize: (bool, bool) -> void
+        def self.reason: (Symbol, allows_non_idempotent_retry: bool, always_retry: bool) -> void
+        def initialize: (name: Symbol, allows_non_idempotent_retry: bool, always_retry: bool) -> void
 
         UNKNOWN: Reason
         SOCKET_NOT_AVAILABLE: Reason

--- a/sig/couchbase/protostellar/retry/strategies.rbs
+++ b/sig/couchbase/protostellar/retry/strategies.rbs
@@ -1,6 +1,4 @@
-# frozen_string_literal: true
-
-#  Copyright 2023-Present. Couchbase, Inc.
+#  Copyright 2023-Present Couchbase, Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -14,12 +12,11 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-require_relative "request_generator/kv"
-require_relative "request_generator/query"
-
 module Couchbase
   module Protostellar
-    module RequestGenerator
+    module Retry
+      module Strategies
+      end
     end
   end
 end

--- a/sig/couchbase/protostellar/retry/strategies.rbs
+++ b/sig/couchbase/protostellar/retry/strategies.rbs
@@ -1,4 +1,4 @@
-#  Copyright 2023-Present Couchbase, Inc.
+#  Copyright 2023. Couchbase, Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/sig/couchbase/protostellar/retry/strategies/best_effort.rbs
+++ b/sig/couchbase/protostellar/retry/strategies/best_effort.rbs
@@ -1,6 +1,4 @@
-# frozen_string_literal: true
-
-#  Copyright 2023-Present. Couchbase, Inc.
+#  Copyright 2023-Present Couchbase, Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -14,12 +12,20 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-require_relative "request_generator/kv"
-require_relative "request_generator/query"
-
 module Couchbase
   module Protostellar
-    module RequestGenerator
+    module Retry
+      module Strategies
+        class BestEffort
+          attr_reader backoff_calculator: ^(Integer) -> Integer
+
+          def initialize: ((^(Integer) -> Integer)?) -> void
+
+          def retry_after: (Request, Retry::Reason) -> Retry::Action
+
+          DEFAULT: BestEffort
+        end
+      end
     end
   end
 end

--- a/sig/couchbase/protostellar/retry/strategies/best_effort.rbs
+++ b/sig/couchbase/protostellar/retry/strategies/best_effort.rbs
@@ -1,4 +1,4 @@
-#  Copyright 2023-Present Couchbase, Inc.
+#  Copyright 2023. Couchbase, Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/spec/couchbase/protostellar/collection_spec.rb
+++ b/spec/couchbase/protostellar/collection_spec.rb
@@ -290,9 +290,9 @@ RSpec.describe Couchbase::Protostellar::Collection do
     end
 
     context "when checking the existence of a non-existent path" do
-      subject(:lookup_in_result) {
+      subject(:lookup_in_result) do
         collection.lookup_in(doc_id, [Couchbase::LookupInSpec.exists("number")])
-      }
+      end
 
       let(:doc_id) { upsert_sample_document }
 

--- a/spec/couchbase/protostellar/retry/orchestrator_spec.rb
+++ b/spec/couchbase/protostellar/retry/orchestrator_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+#  Copyright 2023 Couchbase, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+require "rspec"
+require "couchbase/protostellar/request_generator/kv"
+require "couchbase/protostellar/request_behaviour"
+require "couchbase/protostellar/retry/orchestrator"
+require "couchbase/protostellar/retry/reason"
+require "couchbase/options"
+
+RSpec.describe Couchbase::Protostellar::Retry::Orchestrator do
+  describe "#maybe_retry" do
+    let(:request_generator) do
+      # The requests here do not get executed - just using some placeholder bucket/scope/collection names
+      Couchbase::Protostellar::RequestGenerator::KV.new("default", "foo", "bar")
+    end
+
+    context "when the retry reason allows non-idempotent retries" do
+      subject(:request_behaviour) do
+        request = request_generator.replace_request("a_key", sample_content, Couchbase::Options::Replace::DEFAULT)
+        described_class.maybe_retry(request, Couchbase::Protostellar::Retry::Reason::KV_LOCKED)
+      end
+
+      it "the behaviour is not an error" do
+        expect(request_behaviour.error).to be_nil
+      end
+
+      it "the behaviour has the correct retry duration" do
+        expect(request_behaviour.retry_duration).to be 1
+      end
+    end
+
+    context "when the request is idempotent" do
+      subject(:request_behaviour) do
+        request = request_generator.get_request("a_key", Couchbase::Options::Get::DEFAULT)
+        described_class.maybe_retry(request, Couchbase::Protostellar::Retry::Reason::UNKNOWN)
+      end
+
+      it "the behaviour is not an error" do
+        expect(request_behaviour.error).to be_nil
+      end
+
+      it "the behaviour has the correct retry duration" do
+        expect(request_behaviour.retry_duration).to be 1
+      end
+    end
+
+    context "when the request is idempotent and there have been 2 prior retries" do
+      subject(:request_behaviour) do
+        request = request_generator.get_request("a_key", Couchbase::Options::Get::DEFAULT)
+
+        request.add_retry_attempt(Couchbase::Protostellar::Retry::Reason::UNKNOWN)
+        request.add_retry_attempt(Couchbase::Protostellar::Retry::Reason::UNKNOWN)
+
+        described_class.maybe_retry(request, Couchbase::Protostellar::Retry::Reason::UNKNOWN)
+      end
+
+      it "the behaviour has the correct retry duration according to the default (best effort) strategy" do
+        expect(request_behaviour.retry_duration).to be 4
+      end
+    end
+
+    context "when the request is not idempotent and the retry reason does not allow non-idempotent retries" do
+      subject(:request_behaviour) do
+        request = request_generator.replace_request("a_key", sample_content, Couchbase::Options::Replace::DEFAULT)
+        described_class.maybe_retry(request, Couchbase::Protostellar::Retry::Reason::UNKNOWN)
+      end
+
+      it "the retry duration of the behaviour is nil" do
+        expect(request_behaviour.retry_duration).to be_nil
+      end
+
+      it "the behaviour's error is set" do
+        expect(request_behaviour.error).not_to be_nil
+      end
+
+      it "the behaviour has a RequestCanceled error" do
+        expect(request_behaviour.error.class).to be Couchbase::Error::RequestCanceled
+      end
+    end
+  end
+end

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -36,4 +36,8 @@ module Helpers
   def default_collection(cluster, bucket_name: DEFAULT_BUCKET)
     cluster.bucket(bucket_name).default_collection
   end
+
+  def sample_content
+    {:content => "sample"}
+  end
 end


### PR DESCRIPTION
* Implemented the retry handling RFC
* Added `Protostellar::ErrorHandling` to convert GRPC errors taking into account the GRPC status's detail block
* All requests are now encapsulated in a `Protostellar::Request` object