### PR TITLE
RCBC-409: Implement binary KV operations

### DIFF
--- a/lib/couchbase/protostellar/binary_collection.rb
+++ b/lib/couchbase/protostellar/binary_collection.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+#  Copyright 2023. Couchbase, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+require "couchbase/options"
+
+require_relative "response_converter/kv"
+
+module Couchbase
+  module Protostellar
+    class BinaryCollection
+      def initialize(collection)
+        @collection = collection
+        @client = collection.instance_variable_get(:@client)
+        @kv_request_generator = collection.instance_variable_get(:@kv_request_generator)
+      end
+
+      def append(id, content, options = Options::Append::DEFAULT)
+        req = @kv_request_generator.append_request(id, content, options)
+        resp = @client.send_request(req)
+        ResponseConverter::KV.from_append_response(resp)
+      end
+
+      def prepend(id, content, options = Options::Prepend::DEFAULT)
+        req = @kv_request_generator.prepend_request(id, content, options)
+        resp = @client.send_request(req)
+        ResponseConverter::KV.from_prepend_response(resp)
+      end
+
+      def increment(id, options = Options::Increment::DEFAULT)
+        req = @kv_request_generator.increment_request(id, options)
+        resp = @client.send_request(req)
+        ResponseConverter::KV.from_increment_response(resp)
+      end
+
+      def decrement(id, options = Options::Decrement::DEFAULT)
+        req = @kv_request_generator.decrement_request(id, options)
+        resp = @client.send_request(req)
+        ResponseConverter::KV.from_decrement_response(resp)
+      end
+    end
+  end
+end

--- a/lib/couchbase/protostellar/collection.rb
+++ b/lib/couchbase/protostellar/collection.rb
@@ -20,6 +20,7 @@ require "couchbase/collection_options"
 
 require_relative "request_generator/kv"
 require_relative "response_converter/kv"
+require_relative "binary_collection"
 
 require_relative "generated/kv.v1_pb"
 
@@ -36,6 +37,10 @@ module Couchbase
         @scope_name = scope_name
         @name = name
         @kv_request_generator = RequestGenerator::KV.new(@bucket_name, @scope_name, @name)
+      end
+
+      def binary
+        BinaryCollection.new(self)
       end
 
       def get(id, options = Couchbase::Options::Get::DEFAULT)

--- a/lib/couchbase/protostellar/generated/admin/bucket.v1_services_pb.rb
+++ b/lib/couchbase/protostellar/generated/admin/bucket.v1_services_pb.rb
@@ -12,7 +12,6 @@ module Couchbase
           module V1
             module BucketAdmin
               class Service
-
                 include ::GRPC::GenericService
 
                 self.marshal_class_method = :encode

--- a/lib/couchbase/protostellar/generated/admin/collection.v1_pb.rb
+++ b/lib/couchbase/protostellar/generated/admin/collection.v1_pb.rb
@@ -13,6 +13,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     end
     add_message "couchbase.admin.collection.v1.ListCollectionsResponse.Collection" do
       optional :name, :string, 1
+      proto3_optional :max_expiry_secs, :uint32, 2
     end
     add_message "couchbase.admin.collection.v1.ListCollectionsResponse.Scope" do
       optional :name, :string, 1
@@ -34,6 +35,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
       optional :bucket_name, :string, 1
       optional :scope_name, :string, 2
       optional :collection_name, :string, 3
+      proto3_optional :max_expiry_secs, :uint32, 4
     end
     add_message "couchbase.admin.collection.v1.CreateCollectionResponse" do
     end

--- a/lib/couchbase/protostellar/generated/admin/collection.v1_services_pb.rb
+++ b/lib/couchbase/protostellar/generated/admin/collection.v1_services_pb.rb
@@ -12,18 +12,20 @@ module Couchbase
           module V1
             module CollectionAdmin
               class Service
-
                 include ::GRPC::GenericService
 
                 self.marshal_class_method = :encode
                 self.unmarshal_class_method = :decode
                 self.service_name = 'couchbase.admin.collection.v1.CollectionAdmin'
 
-                rpc :ListCollections, ::Couchbase::Protostellar::Generated::Admin::Collection::V1::ListCollectionsRequest, ::Couchbase::Protostellar::Generated::Admin::Collection::V1::ListCollectionsResponse
+                rpc :ListCollections, ::Couchbase::Protostellar::Generated::Admin::Collection::V1::ListCollectionsRequest,
+                    ::Couchbase::Protostellar::Generated::Admin::Collection::V1::ListCollectionsResponse
                 rpc :CreateScope, ::Couchbase::Protostellar::Generated::Admin::Collection::V1::CreateScopeRequest, ::Couchbase::Protostellar::Generated::Admin::Collection::V1::CreateScopeResponse
                 rpc :DeleteScope, ::Couchbase::Protostellar::Generated::Admin::Collection::V1::DeleteScopeRequest, ::Couchbase::Protostellar::Generated::Admin::Collection::V1::DeleteScopeResponse
-                rpc :CreateCollection, ::Couchbase::Protostellar::Generated::Admin::Collection::V1::CreateCollectionRequest, ::Couchbase::Protostellar::Generated::Admin::Collection::V1::CreateCollectionResponse
-                rpc :DeleteCollection, ::Couchbase::Protostellar::Generated::Admin::Collection::V1::DeleteCollectionRequest, ::Couchbase::Protostellar::Generated::Admin::Collection::V1::DeleteCollectionResponse
+                rpc :CreateCollection, ::Couchbase::Protostellar::Generated::Admin::Collection::V1::CreateCollectionRequest,
+                    ::Couchbase::Protostellar::Generated::Admin::Collection::V1::CreateCollectionResponse
+                rpc :DeleteCollection, ::Couchbase::Protostellar::Generated::Admin::Collection::V1::DeleteCollectionRequest,
+                    ::Couchbase::Protostellar::Generated::Admin::Collection::V1::DeleteCollectionResponse
               end
 
               Stub = Service.rpc_stub_class

--- a/lib/couchbase/protostellar/generated/analytics.v1_services_pb.rb
+++ b/lib/couchbase/protostellar/generated/analytics.v1_services_pb.rb
@@ -11,7 +11,6 @@ module Couchbase
         module V1
           module Analytics
             class Service
-
               include ::GRPC::GenericService
 
               self.marshal_class_method = :encode

--- a/lib/couchbase/protostellar/generated/internal/health.v1_services_pb.rb
+++ b/lib/couchbase/protostellar/generated/internal/health.v1_services_pb.rb
@@ -12,7 +12,6 @@ module Couchbase
           module V1
             module Health
               class Service
-
                 include ::GRPC::GenericService
 
                 self.marshal_class_method = :encode

--- a/lib/couchbase/protostellar/generated/internal/hooks.v1_services_pb.rb
+++ b/lib/couchbase/protostellar/generated/internal/hooks.v1_services_pb.rb
@@ -12,17 +12,19 @@ module Couchbase
           module V1
             module Hooks
               class Service
-
                 include ::GRPC::GenericService
 
                 self.marshal_class_method = :encode
                 self.unmarshal_class_method = :decode
                 self.service_name = 'couchbase.internal.hooks.v1.Hooks'
 
-                rpc :CreateHooksContext, ::Couchbase::Protostellar::Generated::Internal::Hooks::V1::CreateHooksContextRequest, ::Couchbase::Protostellar::Generated::Internal::Hooks::V1::CreateHooksContextResponse
-                rpc :DestroyHooksContext, ::Couchbase::Protostellar::Generated::Internal::Hooks::V1::DestroyHooksContextRequest, ::Couchbase::Protostellar::Generated::Internal::Hooks::V1::DestroyHooksContextResponse
+                rpc :CreateHooksContext, ::Couchbase::Protostellar::Generated::Internal::Hooks::V1::CreateHooksContextRequest,
+                    ::Couchbase::Protostellar::Generated::Internal::Hooks::V1::CreateHooksContextResponse
+                rpc :DestroyHooksContext, ::Couchbase::Protostellar::Generated::Internal::Hooks::V1::DestroyHooksContextRequest,
+                    ::Couchbase::Protostellar::Generated::Internal::Hooks::V1::DestroyHooksContextResponse
                 rpc :AddHooks, ::Couchbase::Protostellar::Generated::Internal::Hooks::V1::AddHooksRequest, ::Couchbase::Protostellar::Generated::Internal::Hooks::V1::AddHooksResponse
-                rpc :WatchBarrier, ::Couchbase::Protostellar::Generated::Internal::Hooks::V1::WatchBarrierRequest, stream(::Couchbase::Protostellar::Generated::Internal::Hooks::V1::WatchBarrierResponse)
+                rpc :WatchBarrier, ::Couchbase::Protostellar::Generated::Internal::Hooks::V1::WatchBarrierRequest,
+                    stream(::Couchbase::Protostellar::Generated::Internal::Hooks::V1::WatchBarrierResponse)
                 rpc :SignalBarrier, ::Couchbase::Protostellar::Generated::Internal::Hooks::V1::SignalBarrierRequest, ::Couchbase::Protostellar::Generated::Internal::Hooks::V1::SignalBarrierResponse
               end
 

--- a/lib/couchbase/protostellar/generated/kv.v1_pb.rb
+++ b/lib/couchbase/protostellar/generated/kv.v1_pb.rb
@@ -29,7 +29,10 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
       optional :scope_name, :string, 2
       optional :collection_name, :string, 3
       optional :key, :string, 4
-      optional :expiry, :message, 5, "google.protobuf.Timestamp"
+      oneof :expiry do
+        optional :expiry_time, :message, 5, "google.protobuf.Timestamp"
+        optional :expiry_secs, :uint32, 6
+      end
     end
     add_message "couchbase.kv.v1.GetAndLockRequest" do
       optional :bucket_name, :string, 1
@@ -50,7 +53,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
       optional :content_type, :enum, 2, "couchbase.kv.v1.DocumentContentType"
       optional :compression_type, :enum, 5, "couchbase.kv.v1.DocumentCompressionType"
       optional :cas, :uint64, 3
-      proto3_optional :expiry, :message, 4, "google.protobuf.Timestamp"
+      optional :expiry, :message, 4, "google.protobuf.Timestamp"
     end
     add_message "couchbase.kv.v1.UnlockRequest" do
       optional :bucket_name, :string, 1
@@ -66,7 +69,10 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
       optional :scope_name, :string, 2
       optional :collection_name, :string, 3
       optional :key, :string, 4
-      optional :expiry, :message, 5, "google.protobuf.Timestamp"
+      oneof :expiry do
+        optional :expiry_time, :message, 5, "google.protobuf.Timestamp"
+        optional :expiry_secs, :uint32, 6
+      end
     end
     add_message "couchbase.kv.v1.TouchResponse" do
       optional :cas, :uint64, 1
@@ -89,10 +95,10 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
       optional :key, :string, 4
       optional :content, :bytes, 5
       optional :content_type, :enum, 6, "couchbase.kv.v1.DocumentContentType"
-      proto3_optional :expiry, :message, 7, "google.protobuf.Timestamp"
-      oneof :durability_spec do
-        optional :legacy_durability_spec, :message, 8, "couchbase.kv.v1.LegacyDurabilitySpec"
-        optional :durability_level, :enum, 9, "couchbase.kv.v1.DurabilityLevel"
+      proto3_optional :durability_level, :enum, 9, "couchbase.kv.v1.DurabilityLevel"
+      oneof :expiry do
+        optional :expiry_time, :message, 7, "google.protobuf.Timestamp"
+        optional :expiry_secs, :uint32, 10
       end
     end
     add_message "couchbase.kv.v1.InsertResponse" do
@@ -106,10 +112,10 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
       optional :key, :string, 4
       optional :content, :bytes, 5
       optional :content_type, :enum, 6, "couchbase.kv.v1.DocumentContentType"
-      proto3_optional :expiry, :message, 7, "google.protobuf.Timestamp"
-      oneof :durability_spec do
-        optional :legacy_durability_spec, :message, 8, "couchbase.kv.v1.LegacyDurabilitySpec"
-        optional :durability_level, :enum, 9, "couchbase.kv.v1.DurabilityLevel"
+      proto3_optional :durability_level, :enum, 9, "couchbase.kv.v1.DurabilityLevel"
+      oneof :expiry do
+        optional :expiry_time, :message, 7, "google.protobuf.Timestamp"
+        optional :expiry_secs, :uint32, 10
       end
     end
     add_message "couchbase.kv.v1.UpsertResponse" do
@@ -124,10 +130,10 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
       optional :content, :bytes, 5
       optional :content_type, :enum, 6, "couchbase.kv.v1.DocumentContentType"
       proto3_optional :cas, :uint64, 7
-      proto3_optional :expiry, :message, 8, "google.protobuf.Timestamp"
-      oneof :durability_spec do
-        optional :legacy_durability_spec, :message, 9, "couchbase.kv.v1.LegacyDurabilitySpec"
-        optional :durability_level, :enum, 10, "couchbase.kv.v1.DurabilityLevel"
+      proto3_optional :durability_level, :enum, 10, "couchbase.kv.v1.DurabilityLevel"
+      oneof :expiry do
+        optional :expiry_time, :message, 8, "google.protobuf.Timestamp"
+        optional :expiry_secs, :uint32, 11
       end
     end
     add_message "couchbase.kv.v1.ReplaceResponse" do
@@ -140,10 +146,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
       optional :collection_name, :string, 3
       optional :key, :string, 4
       proto3_optional :cas, :uint64, 5
-      oneof :durability_spec do
-        optional :legacy_durability_spec, :message, 6, "couchbase.kv.v1.LegacyDurabilitySpec"
-        optional :durability_level, :enum, 7, "couchbase.kv.v1.DurabilityLevel"
-      end
+      proto3_optional :durability_level, :enum, 7, "couchbase.kv.v1.DurabilityLevel"
     end
     add_message "couchbase.kv.v1.RemoveResponse" do
       optional :cas, :uint64, 1
@@ -155,11 +158,11 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
       optional :collection_name, :string, 3
       optional :key, :string, 4
       optional :delta, :uint64, 5
-      proto3_optional :expiry, :message, 6, "google.protobuf.Timestamp"
       proto3_optional :initial, :int64, 7
-      oneof :durability_spec do
-        optional :legacy_durability_spec, :message, 8, "couchbase.kv.v1.LegacyDurabilitySpec"
-        optional :durability_level, :enum, 9, "couchbase.kv.v1.DurabilityLevel"
+      proto3_optional :durability_level, :enum, 9, "couchbase.kv.v1.DurabilityLevel"
+      oneof :expiry do
+        optional :expiry_time, :message, 6, "google.protobuf.Timestamp"
+        optional :expiry_secs, :uint32, 10
       end
     end
     add_message "couchbase.kv.v1.IncrementResponse" do
@@ -173,11 +176,11 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
       optional :collection_name, :string, 3
       optional :key, :string, 4
       optional :delta, :uint64, 5
-      proto3_optional :expiry, :message, 6, "google.protobuf.Timestamp"
       proto3_optional :initial, :int64, 7
-      oneof :durability_spec do
-        optional :legacy_durability_spec, :message, 8, "couchbase.kv.v1.LegacyDurabilitySpec"
-        optional :durability_level, :enum, 9, "couchbase.kv.v1.DurabilityLevel"
+      proto3_optional :durability_level, :enum, 9, "couchbase.kv.v1.DurabilityLevel"
+      oneof :expiry do
+        optional :expiry_time, :message, 6, "google.protobuf.Timestamp"
+        optional :expiry_secs, :uint32, 10
       end
     end
     add_message "couchbase.kv.v1.DecrementResponse" do
@@ -192,10 +195,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
       optional :key, :string, 4
       optional :content, :bytes, 5
       proto3_optional :cas, :uint64, 6
-      oneof :durability_spec do
-        optional :legacy_durability_spec, :message, 7, "couchbase.kv.v1.LegacyDurabilitySpec"
-        optional :durability_level, :enum, 8, "couchbase.kv.v1.DurabilityLevel"
-      end
+      proto3_optional :durability_level, :enum, 8, "couchbase.kv.v1.DurabilityLevel"
     end
     add_message "couchbase.kv.v1.AppendResponse" do
       optional :cas, :uint64, 1
@@ -208,10 +208,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
       optional :key, :string, 4
       optional :content, :bytes, 5
       proto3_optional :cas, :uint64, 6
-      oneof :durability_spec do
-        optional :legacy_durability_spec, :message, 7, "couchbase.kv.v1.LegacyDurabilitySpec"
-        optional :durability_level, :enum, 8, "couchbase.kv.v1.DurabilityLevel"
-      end
+      proto3_optional :durability_level, :enum, 8, "couchbase.kv.v1.DurabilityLevel"
     end
     add_message "couchbase.kv.v1.PrependResponse" do
       optional :cas, :uint64, 1
@@ -256,12 +253,9 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
       optional :key, :string, 4
       repeated :specs, :message, 5, "couchbase.kv.v1.MutateInRequest.Spec"
       proto3_optional :store_semantic, :enum, 6, "couchbase.kv.v1.MutateInRequest.StoreSemantic"
+      proto3_optional :durability_level, :enum, 8, "couchbase.kv.v1.DurabilityLevel"
       proto3_optional :cas, :uint64, 9
       proto3_optional :flags, :message, 10, "couchbase.kv.v1.MutateInRequest.Flags"
-      oneof :durability_spec do
-        optional :legacy_durability_spec, :message, 7, "couchbase.kv.v1.LegacyDurabilitySpec"
-        optional :durability_level, :enum, 8, "couchbase.kv.v1.DurabilityLevel"
-      end
     end
     add_message "couchbase.kv.v1.MutateInRequest.Spec" do
       optional :operation, :enum, 1, "couchbase.kv.v1.MutateInRequest.Spec.Operation"

--- a/lib/couchbase/protostellar/generated/kv.v1_services_pb.rb
+++ b/lib/couchbase/protostellar/generated/kv.v1_services_pb.rb
@@ -11,7 +11,6 @@ module Couchbase
         module V1
           module Kv
             class Service
-
               include ::GRPC::GenericService
 
               self.marshal_class_method = :encode

--- a/lib/couchbase/protostellar/generated/query.v1_services_pb.rb
+++ b/lib/couchbase/protostellar/generated/query.v1_services_pb.rb
@@ -11,7 +11,6 @@ module Couchbase
         module V1
           module Query
             class Service
-
               include ::GRPC::GenericService
 
               self.marshal_class_method = :encode

--- a/lib/couchbase/protostellar/generated/routing.v1_services_pb.rb
+++ b/lib/couchbase/protostellar/generated/routing.v1_services_pb.rb
@@ -11,7 +11,6 @@ module Couchbase
         module V1
           module Routing
             class Service
-
               include ::GRPC::GenericService
 
               self.marshal_class_method = :encode

--- a/lib/couchbase/protostellar/generated/search.v1_services_pb.rb
+++ b/lib/couchbase/protostellar/generated/search.v1_services_pb.rb
@@ -11,7 +11,6 @@ module Couchbase
         module V1
           module Search
             class Service
-
               include ::GRPC::GenericService
 
               self.marshal_class_method = :encode

--- a/lib/couchbase/protostellar/generated/transactions.v1_services_pb.rb
+++ b/lib/couchbase/protostellar/generated/transactions.v1_services_pb.rb
@@ -11,20 +11,25 @@ module Couchbase
         module V1
           module Transactions
             class Service
-
               include ::GRPC::GenericService
 
               self.marshal_class_method = :encode
               self.unmarshal_class_method = :decode
               self.service_name = 'couchbase.transactions.v1.Transactions'
 
-              rpc :TransactionBeginAttempt, ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionBeginAttemptRequest, ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionBeginAttemptResponse
-              rpc :TransactionCommit, ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionCommitRequest, ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionCommitResponse
-              rpc :TransactionRollback, ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionRollbackRequest, ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionRollbackResponse
+              rpc :TransactionBeginAttempt, ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionBeginAttemptRequest,
+                  ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionBeginAttemptResponse
+              rpc :TransactionCommit, ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionCommitRequest,
+                  ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionCommitResponse
+              rpc :TransactionRollback, ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionRollbackRequest,
+                  ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionRollbackResponse
               rpc :TransactionGet, ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionGetRequest, ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionGetResponse
-              rpc :TransactionInsert, ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionInsertRequest, ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionInsertResponse
-              rpc :TransactionReplace, ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionReplaceRequest, ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionReplaceResponse
-              rpc :TransactionRemove, ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionRemoveRequest, ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionRemoveResponse
+              rpc :TransactionInsert, ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionInsertRequest,
+                  ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionInsertResponse
+              rpc :TransactionReplace, ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionReplaceRequest,
+                  ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionReplaceResponse
+              rpc :TransactionRemove, ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionRemoveRequest,
+                  ::Couchbase::Protostellar::Generated::Transactions::V1::TransactionRemoveResponse
             end
 
             Stub = Service.rpc_stub_class

--- a/lib/couchbase/protostellar/generated/view.v1_services_pb.rb
+++ b/lib/couchbase/protostellar/generated/view.v1_services_pb.rb
@@ -11,7 +11,6 @@ module Couchbase
         module V1
           module View
             class Service
-
               include ::GRPC::GenericService
 
               self.marshal_class_method = :encode

--- a/lib/couchbase/protostellar/response_converter/kv.rb
+++ b/lib/couchbase/protostellar/response_converter/kv.rb
@@ -15,6 +15,7 @@
 #  limitations under the License.
 
 require "couchbase/collection_options"
+require "couchbase/binary_collection_options"
 
 module Couchbase
   module Protostellar
@@ -90,6 +91,30 @@ module Couchbase
                 f.value = s.content
               end
             end
+          end
+        end
+
+        def self.from_increment_response(resp)
+          from_counter_response(resp)
+        end
+
+        def self.from_decrement_response(resp)
+          from_counter_response(resp)
+        end
+
+        def self.from_append_response(resp)
+          from_mutation_response(resp)
+        end
+
+        def self.from_prepend_response(resp)
+          from_mutation_response(resp)
+        end
+
+        def self.from_counter_response(resp)
+          Couchbase::BinaryCollection::CounterResult.new do |res|
+            res.cas = resp.cas
+            res.content = resp.content
+            res.mutation_token = extract_mutation_token(resp)
           end
         end
 

--- a/sig/couchbase/protostellar/binary_collection.rbs
+++ b/sig/couchbase/protostellar/binary_collection.rbs
@@ -1,0 +1,15 @@
+module Couchbase
+  module Protostellar
+    class BinaryCollection
+      @collection: Collection
+      @client: Client
+      @kv_request_generator: RequestGenerator::KV
+
+      def initialize: (Collection) -> void
+      def append: (String, String, untyped) -> untyped
+      def prepend: (String, String, untyped) -> untyped
+      def decrement: (String, untyped) -> untyped
+      def increment: (String, untyped) -> untyped
+    end
+  end
+end

--- a/sig/couchbase/protostellar/collection.rbs
+++ b/sig/couchbase/protostellar/collection.rbs
@@ -24,22 +24,16 @@ module Couchbase
 
       def initialize: (Client, String, String, String) -> void
 
+      def binary: () -> BinaryCollection
+
       def get: (String, Couchbase::Options::Get) -> Couchbase::Collection::GetResult
-
       def get_and_touch: (String, untyped, Couchbase::Options::GetAndTouch) -> Couchbase::Collection::GetResult
-
       def get_and_lock: (String, untyped, Couchbase::Options::GetAndLock) -> Couchbase::Collection::GetResult
-
       def unlock: (String, Integer, Couchbase::Options::Unlock) -> void
-
       def upsert: (String, untyped, Couchbase::Options::Upsert) -> Couchbase::Collection::MutationResult
-
       def remove: (String, Couchbase::Options::Remove) -> Couchbase::Collection::MutationResult
-
       def insert: (String, untyped, Couchbase::Options::Insert) -> Couchbase::Collection::MutationResult
-
       def replace: (String, untyped, Couchbase::Options::Replace) -> Couchbase::Collection::MutationResult
-
       def exists: (String, ExistsOptions) -> Couchbase::Collection::ExistsResult
     end
   end

--- a/sig/couchbase/protostellar/request_generator/kv.rbs
+++ b/sig/couchbase/protostellar/request_generator/kv.rbs
@@ -20,6 +20,10 @@ module Couchbase
         def exists_request: (String, untyped) -> untyped
         def mutate_in_request: (String, Array[untyped], untyped) -> untyped
         def lookup_in_request: (String, Array[untyped], untyped) -> untyped
+        def increment_request: (String, untyped) -> untyped
+        def decrement_request: (String, untyped) -> untyped
+        def append_request: (String, String, untyped) -> untyped
+        def prepend_request: (String, String, untyped) -> untyped
 
         private
 
@@ -37,6 +41,7 @@ module Couchbase
         def get_mutate_in_spec_flags: (untyped) -> untyped
         def get_mutate_in_flags: (untyped) -> untyped
         def get_mutate_in_store_semantic: (untyped) -> Symbol
+        def get_encoded: (Object, untyped) -> String
         def get_timeout: (untyped) -> (_CanInMilliseconds | Integer)
       end
     end

--- a/sig/couchbase/protostellar/response_converter/kv.rbs
+++ b/sig/couchbase/protostellar/response_converter/kv.rbs
@@ -2,6 +2,23 @@ module Couchbase
   module Protostellar
     module ResponseConverter
       class KV
+        def self.from_get_response: (untyped, untyped) -> untyped
+        def self.from_upsert_response: (untyped) -> untyped
+        def self.from_remove_response: (untyped) -> untyped
+        def self.from_insert_response: (untyped) -> untyped
+        def self.from_replace_response: (untyped) -> untyped
+        def self.from_exists_response: (untyped) -> untyped
+        def self.from_lookup_in_response: (untyped, untyped, untyped) -> untyped
+        def self.from_mutate_in_response: (untyped, untyped, untyped) -> untyped
+        def self.from_increment_response: (untyped) -> untyped
+        def self.from_decrement_response: (untyped) -> untyped
+        def self.from_append_response: (untyped) -> untyped
+        def self.from_prepend_response: (untyped) -> untyped
+
+        def self.from_mutation_response: (untyped) -> untyped
+        def self.from_counter_response: (untyped) -> untyped
+
+        def self.extract_mutation_token: (untyped) -> untyped
       end
     end
   end

--- a/spec/couchbase/protostellar/binary_collection_spec.rb
+++ b/spec/couchbase/protostellar/binary_collection_spec.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+#  Copyright 2022-Present Couchbase, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+require "rspec"
+require "couchbase/protostellar"
+
+RSpec.describe Couchbase::Protostellar::BinaryCollection do
+  let(:cluster) do
+    connect
+  end
+
+  let(:collection) do
+    default_collection(cluster)
+  end
+
+  let(:binary_collection) do
+    collection.binary
+  end
+
+  describe "#increment" do
+    context "when the document does not exist and initial is not defined" do
+      it "raises a DocumentNotFoundError" do
+        expect { binary_collection.increment(unique_id(:counter)) }.to raise_error(Couchbase::Error::DocumentNotFound)
+      end
+    end
+
+    context "when the document does not exist and initial is defined" do
+      it "sets the value of the counter to the initial value" do
+        opts = Couchbase::Options::Increment(initial: 12)
+        res = binary_collection.increment(unique_id(:counter), opts)
+        expect(res.content).to be 12
+      end
+    end
+
+    context "when the document exists" do
+      before do
+        @doc_id = unique_id(:counter)
+        collection.upsert(@doc_id, 20)
+      end
+
+      it "increments the counter by one" do
+        res = binary_collection.increment(@doc_id)
+        expect(res.content).to be 21
+      end
+    end
+
+    context "when the document exists and delta is set" do
+      before do
+        @doc_id = unique_id(:counter)
+        collection.upsert(@doc_id, 20)
+      end
+
+      it "increments the counter by the value of delta" do
+        opts = Couchbase::Options::Increment(delta: 20)
+        res = binary_collection.increment(@doc_id, opts)
+        expect(res.content).to be 40
+      end
+    end
+  end
+
+  describe "#decrement" do
+    context "when decrementing a document that does not exist without defining an initial value" do
+      it "raises a DocumentNotFoundError" do
+        expect { binary_collection.decrement(unique_id(:counter)) }.to raise_error(Couchbase::Error::DocumentNotFound)
+      end
+    end
+
+    context "when the document does not exist and initial is defined" do
+      it "sets the value of the counter to the initial value" do
+        opts = Couchbase::Options::Decrement(initial: 12)
+        res = binary_collection.decrement(unique_id(:counter), opts)
+        expect(res.content).to be 12
+      end
+    end
+
+    context "when the document exists" do
+      before do
+        @doc_id = unique_id(:counter)
+        collection.upsert(@doc_id, 20)
+      end
+
+      it "decrements the counter by one" do
+        res = binary_collection.decrement(@doc_id)
+        expect(res.content).to be 19
+      end
+    end
+
+    context "when the document exists and delta is set" do
+      before do
+        @doc_id = unique_id(:counter)
+        collection.upsert(@doc_id, 20)
+      end
+
+      it "decrements the counter by the value of delta" do
+        opts = Couchbase::Options::Decrement(delta: 11)
+        res = binary_collection.decrement(@doc_id, opts)
+        expect(res.content).to be 9
+      end
+    end
+  end
+
+  describe "#append" do
+    context "when the document does not exist" do
+      it "raises a DocumentNotFound error" do
+        expect { binary_collection.append(unique_id(:append), "something") }.to raise_error(Couchbase::Error::DocumentNotFound)
+      end
+    end
+
+    context "when the document exists" do
+      before do
+        @doc_id = unique_id(:append)
+        collection.upsert(@doc_id, "|init|", Couchbase::Options::Upsert(transcoder: nil))
+        @mutation_result = binary_collection.append(@doc_id, "something")
+      end
+
+      it "the result has non-zero CAS" do
+        expect(@mutation_result.cas).not_to be 0
+      end
+
+      it "the document has the correct content" do
+        expect(collection.get(@doc_id, Couchbase::Options::Get(transcoder: nil)).content).to eq("|init|something")
+      end
+    end
+  end
+
+  describe "#prepend" do
+    context "when the document does not exist" do
+      it "raises a DocumentNotFound error" do
+        expect { binary_collection.prepend(unique_id(:prepend), "something") }.to raise_error(Couchbase::Error::DocumentNotFound)
+      end
+    end
+
+    context "when the document exists" do
+      before do
+        @doc_id = unique_id(:prepend)
+        collection.upsert(@doc_id, "|init|", Couchbase::Options::Upsert(transcoder: nil))
+        @mutation_result = binary_collection.prepend(@doc_id, "something")
+      end
+
+      it "the result has non-zero CAS" do
+        expect(@mutation_result.cas).not_to be 0
+      end
+
+      it "the document has the correct content" do
+        expect(collection.get(@doc_id, Couchbase::Options::Get(transcoder: nil)).content).to eq("something|init|")
+      end
+    end
+  end
+end

--- a/spec/couchbase/protostellar/collection_spec.rb
+++ b/spec/couchbase/protostellar/collection_spec.rb
@@ -266,9 +266,9 @@ RSpec.describe Couchbase::Protostellar::Collection do
 
   describe "#lookup_in" do
     context "when retrieving a sub-document value" do
-      subject(:lookup_in_result) {
+      subject(:lookup_in_result) do
         collection.lookup_in(doc_id, [Couchbase::LookupInSpec.get("value")])
-      }
+      end
 
       let(:doc_id) { upsert_sample_document }
 
@@ -278,9 +278,9 @@ RSpec.describe Couchbase::Protostellar::Collection do
     end
 
     context "when checking if a path exists" do
-      subject(:lookup_in_result) {
+      subject(:lookup_in_result) do
         collection.lookup_in(doc_id, [Couchbase::LookupInSpec.exists("value")])
-      }
+      end
 
       let(:doc_id) { upsert_sample_document }
 
@@ -304,9 +304,9 @@ RSpec.describe Couchbase::Protostellar::Collection do
 
   describe "#mutate_in" do
     context "when upserting a sub-document" do
-      subject!(:mutate_in_result) {
+      subject!(:mutate_in_result) do
         collection.mutate_in(doc_id, [Couchbase::MutateInSpec.upsert("value", "30")])
-      }
+      end
 
       let(:doc_id) { upsert_sample_document }
 


### PR DESCRIPTION
* Added `Protostellar::BinaryCollection` with `append`, `prepend`, `increment`, `decrement` and relevant tests

Some other small changes:
* Changed `expiry` to `expiry_time` in KV requests because of the breaking changes in Protostellar (will need to revisit expiry to make it fully compatible with the new Protostellar definition)
* Setting content type to `BINARY` in requests when the transcoder is `nil`