### PR TITLE
Update protostellar & bug fixes

### DIFF
--- a/lib/couchbase/protostellar/binary_collection.rb
+++ b/lib/couchbase/protostellar/binary_collection.rb
@@ -30,25 +30,25 @@ module Couchbase
       def append(id, content, options = Options::Append::DEFAULT)
         req = @kv_request_generator.append_request(id, content, options)
         resp = @client.send_request(req)
-        ResponseConverter::KV.from_append_response(resp)
+        ResponseConverter::KV.to_mutation_result(resp)
       end
 
       def prepend(id, content, options = Options::Prepend::DEFAULT)
         req = @kv_request_generator.prepend_request(id, content, options)
         resp = @client.send_request(req)
-        ResponseConverter::KV.from_prepend_response(resp)
+        ResponseConverter::KV.to_mutation_result(resp)
       end
 
       def increment(id, options = Options::Increment::DEFAULT)
         req = @kv_request_generator.increment_request(id, options)
         resp = @client.send_request(req)
-        ResponseConverter::KV.from_increment_response(resp)
+        ResponseConverter::KV.to_counter_result(resp)
       end
 
       def decrement(id, options = Options::Decrement::DEFAULT)
         req = @kv_request_generator.decrement_request(id, options)
         resp = @client.send_request(req)
-        ResponseConverter::KV.from_decrement_response(resp)
+        ResponseConverter::KV.to_counter_result(resp)
       end
     end
   end

--- a/lib/couchbase/protostellar/cluster.rb
+++ b/lib/couchbase/protostellar/cluster.rb
@@ -54,7 +54,7 @@ module Couchbase
       def query(statement, options = Couchbase::Options::Query::DEFAULT)
         req = @query_request_generator.query_request(statement, options)
         resps = @client.send_request(req)
-        ResponseConverter::Query.from_query_responses(resps)
+        ResponseConverter::Query.to_query_result(resps)
       end
     end
   end

--- a/lib/couchbase/protostellar/collection.rb
+++ b/lib/couchbase/protostellar/collection.rb
@@ -44,20 +44,19 @@ module Couchbase
       def get(id, options = Couchbase::Options::Get::DEFAULT)
         req = @kv_request_generator.get_request(id, options)
         resp = @client.send_request(req)
-        ResponseConverter::KV.from_get_response(resp, options)
+        ResponseConverter::KV.to_get_result(resp, options)
       end
 
       def get_and_touch(id, expiry, options = Couchbase::Options::GetAndTouch::DEFAULT)
         req = @kv_request_generator.get_and_touch_request(id, expiry, options)
         resp = @client.send_request(req)
-        ResponseConverter::KV.from_get_response(resp, options)
+        ResponseConverter::KV.to_get_result(resp, options)
       end
 
       def get_and_lock(id, lock_time, options = Couchbase::Options::GetAndLock::DEFAULT)
         req = @kv_request_generator.get_and_lock_request(id, lock_time, options)
         resp = @client.send_request(req)
-        ResponseConverter::KV.from_get_response(resp, options)
-
+        ResponseConverter::KV.to_get_result(resp, options)
       end
 
       def unlock(id, cas, options = Couchbase::Options::Unlock::DEFAULT)
@@ -68,49 +67,49 @@ module Couchbase
       def touch(id, expiry, options = Couchbase::Options::Touch::DEFAULT)
         req = @kv_request_generator.touch_request(id, expiry, options)
         resp = @client.send_request(req)
-        ResponseConverter::KV.from_touch_response(resp)
+        ResponseConverter::KV.to_mutation_result(resp)
       end
 
       def upsert(id, content, options = Couchbase::Options::Upsert::DEFAULT)
         req = @kv_request_generator.upsert_request(id, content, options)
         resp = @client.send_request(req)
-        ResponseConverter::KV.from_upsert_response(resp)
+        ResponseConverter::KV.to_mutation_result(resp)
       end
 
       def remove(id, options = Couchbase::Options::Remove::DEFAULT)
         req = @kv_request_generator.remove_request(id, options)
         resp = @client.send_request(req)
-        ResponseConverter::KV.from_remove_response(resp)
+        ResponseConverter::KV.to_mutation_result(resp)
       end
 
       def insert(id, content, options = Couchbase::Options::Insert::DEFAULT)
         req = @kv_request_generator.insert_request(id, content, options)
         resp = @client.send_request(req)
-        ResponseConverter::KV.from_insert_response(resp)
+        ResponseConverter::KV.to_mutation_result(resp)
       end
 
       def replace(id, content, options = Couchbase::Options::Replace::DEFAULT)
         req = @kv_request_generator.replace_request(id, content, options)
         resp = @client.send_request(req)
-        ResponseConverter::KV.from_replace_response(resp)
+        ResponseConverter::KV.to_mutation_result(resp)
       end
 
       def exists(id, options = Couchbase::Options::Exists::DEFAULT)
         req = @kv_request_generator.exists_request(id, options)
         resp = @client.send_request(req)
-        ResponseConverter::KV.from_exists_response(resp)
+        ResponseConverter::KV.to_exists_result(resp)
       end
 
       def lookup_in(id, specs, options = Couchbase::Options::LookupIn::DEFAULT)
         req = @kv_request_generator.lookup_in_request(id, specs, options)
         resp = @client.send_request(req)
-        ResponseConverter::KV.from_lookup_in_response(resp, specs, options)
+        ResponseConverter::KV.to_lookup_in_result(resp, specs, options)
       end
 
       def mutate_in(id, specs, options = Couchbase::Options::MutateIn::DEFAULT)
         req = @kv_request_generator.mutate_in_request(id, specs, options)
         resp = @client.send_request(req)
-        ResponseConverter::KV.from_mutate_in_response(resp, specs, options)
+        ResponseConverter::KV.to_mutate_in_result(resp, specs, options)
       end
     end
   end

--- a/lib/couchbase/protostellar/error.rb
+++ b/lib/couchbase/protostellar/error.rb
@@ -12,6 +12,9 @@ module Couchbase
 
       class InvalidRetryBehaviour < ProtostellarError
       end
+
+      class InvalidExpiryType < ProtostellarError
+      end
     end
   end
 end

--- a/lib/couchbase/protostellar/generated/kv/v1/kv_pb.rb
+++ b/lib/couchbase/protostellar/generated/kv/v1/kv_pb.rb
@@ -26,8 +26,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     end
     add_message "couchbase.kv.v1.GetResponse" do
       optional :content, :bytes, 1
-      optional :content_type, :enum, 2, "couchbase.kv.v1.DocumentContentType"
-      optional :compression_type, :enum, 5, "couchbase.kv.v1.DocumentCompressionType"
+      optional :content_flags, :uint32, 6
       optional :cas, :uint64, 3
       optional :expiry, :message, 4, "google.protobuf.Timestamp"
     end
@@ -43,8 +42,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     end
     add_message "couchbase.kv.v1.GetAndTouchResponse" do
       optional :content, :bytes, 1
-      optional :content_type, :enum, 2, "couchbase.kv.v1.DocumentContentType"
-      optional :compression_type, :enum, 5, "couchbase.kv.v1.DocumentCompressionType"
+      optional :content_flags, :uint32, 6
       optional :cas, :uint64, 3
       optional :expiry, :message, 4, "google.protobuf.Timestamp"
     end
@@ -57,8 +55,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     end
     add_message "couchbase.kv.v1.GetAndLockResponse" do
       optional :content, :bytes, 1
-      optional :content_type, :enum, 2, "couchbase.kv.v1.DocumentContentType"
-      optional :compression_type, :enum, 5, "couchbase.kv.v1.DocumentCompressionType"
+      optional :content_flags, :uint32, 6
       optional :cas, :uint64, 3
       optional :expiry, :message, 4, "google.protobuf.Timestamp"
     end
@@ -71,8 +68,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     end
     add_message "couchbase.kv.v1.GetReplicaResponse" do
       optional :content, :bytes, 1
-      optional :content_type, :enum, 2, "couchbase.kv.v1.DocumentContentType"
-      optional :compression_type, :enum, 5, "couchbase.kv.v1.DocumentCompressionType"
+      optional :content_flags, :uint32, 6
       optional :cas, :uint64, 3
       optional :expiry, :message, 4, "google.protobuf.Timestamp"
     end
@@ -115,7 +111,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
       optional :collection_name, :string, 3
       optional :key, :string, 4
       optional :content, :bytes, 5
-      optional :content_type, :enum, 6, "couchbase.kv.v1.DocumentContentType"
+      optional :content_flags, :uint32, 11
       proto3_optional :durability_level, :enum, 9, "couchbase.kv.v1.DurabilityLevel"
       oneof :expiry do
         optional :expiry_time, :message, 7, "google.protobuf.Timestamp"
@@ -132,7 +128,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
       optional :collection_name, :string, 3
       optional :key, :string, 4
       optional :content, :bytes, 5
-      optional :content_type, :enum, 6, "couchbase.kv.v1.DocumentContentType"
+      optional :content_flags, :uint32, 11
       proto3_optional :durability_level, :enum, 9, "couchbase.kv.v1.DurabilityLevel"
       oneof :expiry do
         optional :expiry_time, :message, 7, "google.protobuf.Timestamp"
@@ -149,7 +145,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
       optional :collection_name, :string, 3
       optional :key, :string, 4
       optional :content, :bytes, 5
-      optional :content_type, :enum, 6, "couchbase.kv.v1.DocumentContentType"
+      optional :content_flags, :uint32, 12
       proto3_optional :cas, :uint64, 7
       proto3_optional :durability_level, :enum, 10, "couchbase.kv.v1.DurabilityLevel"
       oneof :expiry do
@@ -277,6 +273,10 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
       proto3_optional :durability_level, :enum, 8, "couchbase.kv.v1.DurabilityLevel"
       proto3_optional :cas, :uint64, 9
       proto3_optional :flags, :message, 10, "couchbase.kv.v1.MutateInRequest.Flags"
+      oneof :expiry do
+        optional :expiry_time, :message, 11, "google.protobuf.Timestamp"
+        optional :expiry_secs, :uint32, 12
+      end
     end
     add_message "couchbase.kv.v1.MutateInRequest.Spec" do
       optional :operation, :enum, 1, "couchbase.kv.v1.MutateInRequest.Spec.Operation"
@@ -348,26 +348,15 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
       proto3_optional :meta_data, :message, 3, "couchbase.kv.v1.RangeScanResponse.Document.MetaData"
     end
     add_message "couchbase.kv.v1.RangeScanResponse.Document.MetaData" do
-      optional :flags, :uint32, 1
+      optional :content_flags, :uint32, 1
       proto3_optional :expiry, :message, 2, "google.protobuf.Timestamp"
       optional :seqno, :uint64, 3
       optional :cas, :uint64, 4
-      optional :content_type, :enum, 5, "couchbase.kv.v1.DocumentContentType"
-      optional :compression_type, :enum, 6, "couchbase.kv.v1.DocumentCompressionType"
     end
     add_enum "couchbase.kv.v1.DurabilityLevel" do
       value :DURABILITY_LEVEL_MAJORITY, 0
       value :DURABILITY_LEVEL_MAJORITY_AND_PERSIST_TO_ACTIVE, 1
       value :DURABILITY_LEVEL_PERSIST_TO_MAJORITY, 2
-    end
-    add_enum "couchbase.kv.v1.DocumentContentType" do
-      value :DOCUMENT_CONTENT_TYPE_UNKNOWN, 0
-      value :DOCUMENT_CONTENT_TYPE_BINARY, 1
-      value :DOCUMENT_CONTENT_TYPE_JSON, 2
-    end
-    add_enum "couchbase.kv.v1.DocumentCompressionType" do
-      value :DOCUMENT_COMPRESSION_TYPE_NONE, 0
-      value :DOCUMENT_COMPRESSION_TYPE_SNAPPY, 1
     end
   end
 end
@@ -432,8 +421,6 @@ module Couchbase
           RangeScanResponse::Document = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("couchbase.kv.v1.RangeScanResponse.Document").msgclass
           RangeScanResponse::Document::MetaData = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("couchbase.kv.v1.RangeScanResponse.Document.MetaData").msgclass
           DurabilityLevel = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("couchbase.kv.v1.DurabilityLevel").enummodule
-          DocumentContentType = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("couchbase.kv.v1.DocumentContentType").enummodule
-          DocumentCompressionType = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("couchbase.kv.v1.DocumentCompressionType").enummodule
         end
       end
     end

--- a/lib/couchbase/protostellar/management/collection_manager.rb
+++ b/lib/couchbase/protostellar/management/collection_manager.rb
@@ -32,7 +32,7 @@ module Couchbase
         def get_all_scopes(options = Couchbase::Management::Options::Collection::GetAllScopes.new)
           req = @request_generator.list_collections_request(options)
           resp = @client.send_request(req)
-          ResponseConverter::Admin::Collection.from_list_collections_response(resp)
+          ResponseConverter::Admin::Collection.to_scope_spec_array(resp)
         end
 
         def create_scope(scope_name, options = Couchbase::Management::Options::Collection::CreateScope.new)

--- a/lib/couchbase/protostellar/request.rb
+++ b/lib/couchbase/protostellar/request.rb
@@ -47,6 +47,7 @@ module Couchbase
         @retry_attempts = 0
         @retry_reasons = Set.new
         @retry_strategy = retry_strategy
+        @context = {}
       end
 
       def deadline
@@ -60,6 +61,10 @@ module Couchbase
       def add_retry_attempt(reason)
         @retry_reasons.add(reason)
         @retry_attempts += 1
+      end
+
+      def error_context
+        @context.merge({retry_reasons: @retry_reasons.to_a, retry_attempts: @retry_attempts})
       end
     end
   end

--- a/lib/couchbase/protostellar/request_generator/query.rb
+++ b/lib/couchbase/protostellar/request_generator/query.rb
@@ -78,13 +78,12 @@ module Couchbase
             **proto_opts
           )
 
-          idempotent = options.readonly ? true : false
-          create_query_request(proto_req, :query, options, idempotent)
+          create_query_request(proto_req, :query, options, idempotent: options.readonly && true)
         end
 
         private
 
-        def create_query_request(proto_request, rpc, options, idempotent = false)
+        def create_query_request(proto_request, rpc, options, idempotent: false)
           Request.new(
             service: :query,
             rpc: rpc,

--- a/lib/couchbase/protostellar/response_converter/admin/collection.rb
+++ b/lib/couchbase/protostellar/response_converter/admin/collection.rb
@@ -21,7 +21,7 @@ module Couchbase
     module ResponseConverter
       module Admin
         class Collection
-          def self.from_list_collections_response(resp)
+          def self.to_scope_spec_array(resp)
             resp.scopes.map do |s|
               Couchbase::Management::ScopeSpec.new do |scope_spec|
                 scope_spec.name = s.name

--- a/lib/couchbase/protostellar/response_converter/query.rb
+++ b/lib/couchbase/protostellar/response_converter/query.rb
@@ -35,7 +35,7 @@ module Couchbase
           :STATUS_UNKNOWN => :unknown,
         }.freeze
 
-        def self.from_query_responses(resps)
+        def self.to_query_result(resps)
           Couchbase::Cluster::QueryResult.new do |res|
             rows = []
             resps.each do |resp|

--- a/lib/couchbase/protostellar/retry/strategies/best_effort.rb
+++ b/lib/couchbase/protostellar/retry/strategies/best_effort.rb
@@ -23,10 +23,10 @@ module Couchbase
 
           def initialize(backoff_calculator = nil)
             # The default backoff calculator starts with a 1 millisecond backoff and doubles it after each retry
-            # attempt, up to a maximum of 50 milliseconds
+            # attempt, up to a maximum of 500 milliseconds
             @backoff_calculator =
               if backoff_calculator.nil?
-                lambda { |retry_attempt_count| [2**retry_attempt_count, 50].min }
+                lambda { |retry_attempt_count| [2**retry_attempt_count, 500].min }
               else
                 backoff_calculator
               end

--- a/lib/couchbase/protostellar/scope.rb
+++ b/lib/couchbase/protostellar/scope.rb
@@ -40,12 +40,8 @@ module Couchbase
 
       def query(statement, options = Couchbase::Options::Query::DEFAULT)
         req = @query_request_generator.query_request(statement, options)
-        begin
-          resps = @client.query(req, timeout: options.timeout)
-        rescue GRPC::DeadlineExceeded
-          raise Couchbase::Error::Timeout
-        end
-        ResponseConverter::Query.from_query_responses(resps)
+        resps = @client.send_request(req)
+        ResponseConverter::Query.to_query_result(resps)
       end
     end
   end

--- a/sig/couchbase/protostellar/collection.rbs
+++ b/sig/couchbase/protostellar/collection.rbs
@@ -35,7 +35,9 @@ module Couchbase
       def remove: (String, Couchbase::Options::Remove) -> Couchbase::Collection::MutationResult
       def insert: (String, untyped, Couchbase::Options::Insert) -> Couchbase::Collection::MutationResult
       def replace: (String, untyped, Couchbase::Options::Replace) -> Couchbase::Collection::MutationResult
-      def exists: (String, ExistsOptions) -> Couchbase::Collection::ExistsResult
+      def exists: (String, Couchbase::Options::Exists) -> Couchbase::Collection::ExistsResult
+      def lookup_in: (String, Array[Couchbase::LookupInSpec], Couchbase::Options::LookupIn) -> Couchbase::Collection::LookupInResult
+      def mutate_in: (String, Array[Couchbase::MutateInSpec], Couchbase::Options::MutateIn) -> Couchbase::Collection::MutateInResult
     end
   end
 end

--- a/sig/couchbase/protostellar/request.rbs
+++ b/sig/couchbase/protostellar/request.rbs
@@ -38,8 +38,8 @@ module Couchbase
         ) -> void
 
       def deadline: () -> untyped
-
       def add_retry_attempt: (Retry::Reason) -> void
+      def error_context: () -> Hash[Symbol, any]
     end
   end
 end

--- a/sig/couchbase/protostellar/request_generator/kv.rbs
+++ b/sig/couchbase/protostellar/request_generator/kv.rbs
@@ -1,3 +1,17 @@
+#  Copyright 2023. Couchbase, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 module Couchbase
   module Protostellar
     module RequestGenerator
@@ -35,10 +49,9 @@ module Couchbase
 
         private
 
-        def create_kv_request: (untyped, Symbol, untyped) -> untyped
+        def create_kv_request: (untyped, Symbol, untyped, idempotent: bool) -> untyped
 
-        def get_expiry: (untyped) -> untyped
-        def get_content_type: (untyped) -> Symbol
+        def get_expiry: (untyped) -> [(:expiry_time | :expiry_secs)?, (Google::Protobuf::Timestamp | Integer)?]
         def get_durability_level: (untyped) -> Symbol?
         def get_lookup_in_spec: (untyped) -> untyped
         def get_lookup_in_operation: (untyped) -> untyped
@@ -49,7 +62,7 @@ module Couchbase
         def get_mutate_in_spec_flags: (untyped) -> untyped
         def get_mutate_in_flags: (untyped) -> untyped
         def get_mutate_in_store_semantic: (untyped) -> Symbol
-        def get_encoded: (Object, untyped) -> String
+        def get_encoded: (Object, untyped) -> [String, Integer]
         def get_timeout: (untyped) -> (_CanInMilliseconds | Integer)
       end
     end

--- a/sig/couchbase/protostellar/request_generator/query.rbs
+++ b/sig/couchbase/protostellar/request_generator/query.rbs
@@ -1,3 +1,17 @@
+#  Copyright 2023. Couchbase, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 module Couchbase
   module Protostellar
     module RequestGenerator
@@ -19,7 +33,7 @@ module Couchbase
 
         private
 
-        def create_query_request: (untyped, Symbol, untyped) -> untyped
+        def create_query_request: (untyped, Symbol, untyped, idempotent: bool) -> untyped
         def create_tuning_options: (untyped) -> untyped
         def get_timeout: (untyped) -> (_CanInMilliseconds | Integer)
       end

--- a/sig/couchbase/protostellar/response_converter/admin/collection.rbs
+++ b/sig/couchbase/protostellar/response_converter/admin/collection.rbs
@@ -17,11 +17,7 @@ module Couchbase
     module ResponseConverter
       module Admin
         class Collection
-          def self.from_list_collections_response: (untyped resp) -> Array[untyped]
-          def self.from_create_scope_response: (untyped resp) -> untyped
-          def self.from_delete_scope_response: (untyped resp) -> untyped
-          def self.from_create_collection_response: (untyped resp) -> untyped
-          def self.from_delete_collection_response: (untyped resp) -> untyped
+          def self.to_scope_spec_array: (untyped resp) -> Array[untyped]
         end
       end
     end

--- a/sig/couchbase/protostellar/response_converter/kv.rbs
+++ b/sig/couchbase/protostellar/response_converter/kv.rbs
@@ -1,23 +1,27 @@
+#  Copyright 2023. Couchbase, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 module Couchbase
   module Protostellar
     module ResponseConverter
       class KV
-        def self.from_get_response: (untyped, untyped) -> untyped
-        def self.from_touch_response: (untyped) -> untyped
-        def self.from_upsert_response: (untyped) -> untyped
-        def self.from_remove_response: (untyped) -> untyped
-        def self.from_insert_response: (untyped) -> untyped
-        def self.from_replace_response: (untyped) -> untyped
-        def self.from_exists_response: (untyped) -> untyped
-        def self.from_lookup_in_response: (untyped, untyped, untyped) -> untyped
-        def self.from_mutate_in_response: (untyped, untyped, untyped) -> untyped
-        def self.from_increment_response: (untyped) -> untyped
-        def self.from_decrement_response: (untyped) -> untyped
-        def self.from_append_response: (untyped) -> untyped
-        def self.from_prepend_response: (untyped) -> untyped
-
-        def self.from_mutation_response: (untyped) -> untyped
-        def self.from_counter_response: (untyped) -> untyped
+        def self.to_get_result: (untyped resp, untyped options) -> untyped
+        def self.to_mutation_result: (untyped resp) -> untyped
+        def self.to_exists_result: (untyped resp) -> untyped
+        def self.to_counter_result: (untyped resp) -> untyped
+        def self.to_lookup_in_result: (untyped resp, untyped specs, untyped options) -> untyped
+        def self.to_mutate_in_result: (untyped resp, untyped specs, untyped options) -> untyped
 
         def self.extract_mutation_token: (untyped) -> untyped
       end

--- a/sig/couchbase/protostellar/response_converter/query.rbs
+++ b/sig/couchbase/protostellar/response_converter/query.rbs
@@ -1,8 +1,24 @@
+#  Copyright 2023. Couchbase, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 module Couchbase
   module Protostellar
     module ResponseConverter
       class Query
-        def self.from_query_responses: (Enumerable[untyped] resps) -> untyped
+        STATUS_MAP: Hash[Symbol, Symbol]
+
+        def self.to_query_result: (Enumerable[untyped] resps) -> untyped
         def self.convert_query_metadata: (untyped proto_metadata) -> untyped
         def self.convert_query_warning: (untyped proto_warning) -> untyped
         def self.convert_query_metrics: (untyped proto_metrics) -> untyped

--- a/spec/couchbase/protostellar/collection_spec.rb
+++ b/spec/couchbase/protostellar/collection_spec.rb
@@ -267,7 +267,7 @@ RSpec.describe Couchbase::Protostellar::Collection do
   describe "#get_and_lock" do
     context "when the document exists and is not locked" do
       let(:doc_id) { upsert_sample_document }
-      let(:get_result) { collection.get_and_lock(doc_id, 10) }
+      let!(:get_result) { collection.get_and_lock(doc_id, 10) }
 
       it "fetches the document" do
         expect(get_result.cas).not_to be 0
@@ -330,7 +330,7 @@ RSpec.describe Couchbase::Protostellar::Collection do
 
       it "sets the expiration" do
         collection.touch(doc_id, 1)
-        sleep(2)
+        sleep(5)
         expect { collection.get(doc_id) }.to raise_error(Couchbase::Error::DocumentNotFound)
       end
     end


### PR DESCRIPTION
* Updated protostellar
* Expiry now makes use of the ability to specify either `expiry_secs` or `expiry_time`
* Some small bug fixes in retry/error handling
* Tidied up the methods in the response converters
* Replaced `content_type` with the new `content_flags` attribute in protostellar requests
* Fixed issue in the `#get_and_lock` test