### PR TITLE
Query index management fixes

### DIFF
--- a/ext/couchbase.cxx
+++ b/ext/couchbase.cxx
@@ -5090,6 +5090,14 @@ cb_Backend_query_index_get_all(VALUE self, VALUE bucket_name, VALUE options)
         couchbase::core::operations::management::query_index_get_all_request req{};
         req.bucket_name = cb_string_new(bucket_name);
         cb_extract_timeout(req, options);
+        if (!NIL_P(options)) {
+            if (VALUE scope_name = rb_hash_aref(options, rb_id2sym(rb_intern("scope_name"))); TYPE(scope_name) == T_STRING) {
+                req.scope_name = cb_string_new(scope_name);
+            }
+            if (VALUE collection_name = rb_hash_aref(options, rb_id2sym(rb_intern("collection_name"))); TYPE(collection_name) == T_STRING) {
+                req.collection_name = cb_string_new(collection_name);
+            }
+        }
         auto barrier = std::make_shared<std::promise<couchbase::core::operations::management::query_index_get_all_response>>();
         auto f = barrier->get_future();
         cluster->execute(req, [barrier](couchbase::core::operations::management::query_index_get_all_response&& resp) {
@@ -5466,15 +5474,51 @@ cb_Backend_query_index_build_deferred(VALUE self, VALUE bucket_name, VALUE optio
     }
 
     try {
-        couchbase::build_query_index_options opts;
-        couchbase::ruby::set_timeout(opts, options);
-        auto bucket = cb_string_new(bucket_name);
+        couchbase::core::operations::management::query_index_build_deferred_request req{};
+        cb_extract_timeout(req, options);
+        req.bucket_name = cb_string_new(bucket_name);
 
-        auto f = couchbase::cluster(cluster).query_indexes().build_deferred_indexes(bucket, opts);
-        if (auto ctx = cb_wait_for_future(f); ctx.ec()) {
-            cb_throw_error_code(ctx, fmt::format("unable to trigger build for deferred indexes for the bucket \"{}\"", bucket));
+        if (!NIL_P(options)) {
+            if (VALUE scope_name = rb_hash_aref(options, rb_id2sym(rb_intern("scope_name"))); TYPE(scope_name) == T_STRING) {
+                req.scope_name = cb_string_new(scope_name);
+            }
+            if (VALUE collection_name = rb_hash_aref(options, rb_id2sym(rb_intern("collection_name"))); TYPE(collection_name) == T_STRING) {
+                req.collection_name = cb_string_new(collection_name);
+            }
         }
-        return Qtrue;
+
+        auto barrier = std::make_shared<std::promise<couchbase::core::operations::management::query_index_build_deferred_response>>();
+        auto f = barrier->get_future();
+        cluster->execute(req, [barrier](couchbase::core::operations::management::query_index_build_deferred_response&& resp) {
+            barrier->set_value(std::move(resp));
+        });
+        auto resp = cb_wait_for_future(f);
+        if (resp.ctx.ec) {
+            if (!resp.errors.empty()) {
+                const auto& first_error = resp.errors.front();
+                cb_throw_error_code(resp.ctx,
+                                    fmt::format(R"(unable to build deferred indexes on the bucket "{}" ({}: {}))",
+                                                req.bucket_name,
+                                                first_error.code,
+                                                first_error.message));
+            } else {
+                cb_throw_error_code(resp.ctx,
+                                    fmt::format(R"(unable to build deferred indexes on the bucket "{}")", req.bucket_name));
+            }
+        }
+        VALUE res = rb_hash_new();
+        rb_hash_aset(res, rb_id2sym(rb_intern("status")), cb_str_new(resp.status));
+        if (!resp.errors.empty()) {
+            VALUE errors = rb_ary_new_capa(static_cast<long>(resp.errors.size()));
+            for (const auto& err : resp.errors) {
+                VALUE error = rb_hash_new();
+                rb_hash_aset(error, rb_id2sym(rb_intern("code")), ULL2NUM(err.code));
+                rb_hash_aset(error, rb_id2sym(rb_intern("message")), cb_str_new(err.message));
+                rb_ary_push(errors, error);
+            }
+            rb_hash_aset(res, rb_id2sym(rb_intern("errors")), errors);
+        }
+        return res;
     } catch (const std::system_error& se) {
         rb_exc_raise(cb_map_error_code(se.code(), fmt::format("failed to perform {}: {}", __func__, se.what()), false));
     } catch (const ruby_exception& e) {

--- a/lib/couchbase/management/collection_query_index_manager.rb
+++ b/lib/couchbase/management/collection_query_index_manager.rb
@@ -14,6 +14,7 @@
 
 require "couchbase/management/query_index_manager"
 require "couchbase/utils/time"
+require "couchbase/errors"
 
 module Couchbase
   module Management
@@ -37,8 +38,16 @@ module Couchbase
       #
       # @return [Array<QueryIndex>]
       #
-      # @raise [ArgumentError]
+      # @raise [Error::InvalidArgument]
       def get_all_indexes(options = Options::Query::GetAllIndexes.new)
+        unless options.scope_name.nil?
+          raise Error::InvalidArgument, "Scope name cannot be set in the options when using the Query Index manager at the collection level"
+        end
+
+        unless options.collection_name.nil?
+          raise Error::InvalidArgument, "Collection name cannot be set in the options when using the Query Index manager at the collection level"
+        end
+
         res = @backend.collection_query_index_get_all(@bucket_name, @scope_name, @collection_name, options.to_backend)
         res[:indexes].map do |idx|
           QueryIndex.new do |index|
@@ -64,15 +73,15 @@ module Couchbase
       #
       # @return void
       #
-      # @raise [ArgumentError]
+      # @raise [Error::InvalidArgument]
       # @raise [Error::IndexExists]
       def create_index(index_name, fields, options = Options::Query::CreateIndex.new)
         unless options.scope_name.nil?
-          raise ArgumentError, "Scope name cannot be set in the options when using the Query Index manager at the collection level"
+          raise Error::InvalidArgument, "Scope name cannot be set in the options when using the Query Index manager at the collection level"
         end
 
         unless options.collection_name.nil?
-          raise ArgumentError, "Collection name cannot be set in the options when using the Query Index manager at the collection level"
+          raise Error::InvalidArgument, "Collection name cannot be set in the options when using the Query Index manager at the collection level"
         end
 
         @backend.collection_query_index_create(@bucket_name, @scope_name, @collection_name, index_name, fields, options.to_backend)
@@ -84,15 +93,15 @@ module Couchbase
       #
       # @return void
       #
-      # @raise [ArgumentError]
+      # @raise [Error::InvalidArgument]
       # @raise [Error::IndexExists]
       def create_primary_index(options = Options::Query::CreatePrimaryIndex.new)
         unless options.scope_name.nil?
-          raise ArgumentError, "Scope name cannot be set in the options when using the Query Index manager at the collection level"
+          raise Error::InvalidArgument, "Scope name cannot be set in the options when using the Query Index manager at the collection level"
         end
 
         unless options.collection_name.nil?
-          raise ArgumentError, "Collection name cannot be set in the options when using the Query Index manager at the collection level"
+          raise Error::InvalidArgument, "Collection name cannot be set in the options when using the Query Index manager at the collection level"
         end
 
         @backend.collection_query_index_create_primary(@bucket_name, @scope_name, @collection_name, options.to_backend)
@@ -105,15 +114,15 @@ module Couchbase
       #
       # @return void
       #
-      # @raise [ArgumentError]
+      # @raise [Error::InvalidArgument]
       # @raise [Error::IndexNotFound]
       def drop_index(index_name, options = Options::Query::DropIndex.new)
         unless options.scope_name.nil?
-          raise ArgumentError, "Scope name cannot be set in the options when using the Query Index manager at the collection level"
+          raise Error::InvalidArgument, "Scope name cannot be set in the options when using the Query Index manager at the collection level"
         end
 
         unless options.collection_name.nil?
-          raise ArgumentError, "Collection name cannot be set in the options when using the Query Index manager at the collection level"
+          raise Error::InvalidArgument, "Collection name cannot be set in the options when using the Query Index manager at the collection level"
         end
 
         @backend.collection_query_index_drop(@bucket_name, @scope_name, @collection_name, index_name, options.to_backend)
@@ -125,15 +134,15 @@ module Couchbase
       #
       # @return void
       #
-      # @raise [ArgumentError]
+      # @raise [Error::InvalidArgument]
       # @raise [Error::IndexNotFound]
       def drop_primary_index(options = Options::Query::DropPrimaryIndex.new)
         unless options.scope_name.nil?
-          raise ArgumentError, "Scope name cannot be set in the options when using the Query Index manager at the collection level"
+          raise Error::InvalidArgument, "Scope name cannot be set in the options when using the Query Index manager at the collection level"
         end
 
         unless options.collection_name.nil?
-          raise ArgumentError, "Collection name cannot be set in the options when using the Query Index manager at the collection level"
+          raise Error::InvalidArgument, "Collection name cannot be set in the options when using the Query Index manager at the collection level"
         end
 
         @backend.collection_query_index_drop_primary(@bucket_name, @scope_name, @collection_name, options.to_backend)
@@ -145,8 +154,16 @@ module Couchbase
       #
       # @return void
       #
-      # @raise [ArgumentError]
+      # @raise [Error::InvalidArgument]
       def build_deferred_indexes(options = Options::Query::BuildDeferredIndexes.new)
+        unless options.scope_name.nil?
+          raise Error::InvalidArgument, "Scope name cannot be set in the options when using the Query Index manager at the collection level"
+        end
+
+        unless options.collection_name.nil?
+          raise Error::InvalidArgument, "Collection name cannot be set in the options when using the Query Index manager at the collection level"
+        end
+
         @backend.collection_query_index_build_deferred(@bucket_name, @scope_name, @collection_name, options.to_backend)
       end
 
@@ -156,9 +173,17 @@ module Couchbase
       # @param [Integer, #in_milliseconds] timeout the time in milliseconds allowed for the operation to complete
       # @param [Options::Query::WatchIndexes] options
       #
-      # @raise [ArgumentError]
+      # @raise [Error::InvalidArgument]
       # @raise [Error::IndexNotFound]
       def watch_indexes(index_names, timeout, options = Options::Query::WatchIndexes.new)
+        unless options.scope_name.nil?
+          raise Error::InvalidArgument, "Scope name cannot be set in the options when using the Query Index manager at the collection level"
+        end
+
+        unless options.collection_name.nil?
+          raise Error::InvalidArgument, "Collection name cannot be set in the options when using the Query Index manager at the collection level"
+        end
+
         index_names.append("#primary") if options.watch_primary
 
         interval_millis = 50


### PR DESCRIPTION
* Added `scope_name` and `collection_name` to the options for `get_all_indexes`, `build_deferred_indexes` and `watch_indexes
* Added `index_name` to the options for `create_primary_index`
* Replaced `ArgumentError`s in query index management operations with `Error::InvalidArgument` errors
* Use the core API for `build_deferred_indexes`