### PR TITLE
RCBC-420: Support RawJson, RawBinary and RawString transcoders & check flag when decoding

### DIFF
--- a/lib/couchbase/raw_binary_transcoder.rb
+++ b/lib/couchbase/raw_binary_transcoder.rb
@@ -19,7 +19,7 @@ module Couchbase
     # @param [String] document
     # @return [Array<String, Integer>] pair of encoded document and flags
     def encode(document)
-      raise Error::EncodingFailure, "Only binary data supported by RawJsonTranscoder" unless document.is_a?(String)
+      raise Error::EncodingFailure, "Only binary data supported by RawBinaryTranscoder" unless document.is_a?(String)
 
       [document, TranscoderFlags.new(format: :binary).encode]
     end

--- a/lib/couchbase/raw_binary_transcoder.rb
+++ b/lib/couchbase/raw_binary_transcoder.rb
@@ -1,4 +1,4 @@
-#  Copyright 2020-2021 Couchbase, Inc.
+#  Copyright 2023. Couchbase, Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -12,28 +12,26 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-require "json"
-
 require "couchbase/transcoder_flags"
 
 module Couchbase
-  class JsonTranscoder
-    # @param [Object] document
+  class RawBinaryTranscoder
+    # @param [String] document
     # @return [Array<String, Integer>] pair of encoded document and flags
     def encode(document)
-      raise Error::EncodingFailure, "The JsonTranscoder does not support binary data" if document.is_a?(String) && !document.valid_encoding?
+      raise Error::EncodingFailure, "Only binary data supported by RawJsonTranscoder" unless document.is_a?(String)
 
-      [JSON.generate(document), TranscoderFlags.new(format: :json, lower_bits: 6).encode]
+      [document, TranscoderFlags.new(format: :binary).encode]
     end
 
     # @param [String] blob string of bytes, containing encoded representation of the document
-    # @param [Integer, :json] flags bit field, describing how the data encoded
-    # @return [Object] decoded document
+    # @param [Integer] flags bit field, describing how the data encoded
+    # @return [String] decoded document
     def decode(blob, flags)
       format = TranscoderFlags.decode(flags).format
-      raise Error::DecodingFailure, "Unable to decode #{format} with the JsonTranscoder" unless format == :json || format.nil?
+      raise Error::DecodingFailure, "Unable to decode #{format} with the RawBinaryTranscoder" unless format == :binary || format.nil?
 
-      JSON.parse(blob) unless blob&.empty?
+      blob
     end
   end
 end

--- a/lib/couchbase/raw_json_transcoder.rb
+++ b/lib/couchbase/raw_json_transcoder.rb
@@ -1,4 +1,4 @@
-#  Copyright 2020-2021 Couchbase, Inc.
+#  Copyright 2023. Couchbase, Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -12,28 +12,27 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-require "json"
-
 require "couchbase/transcoder_flags"
+require "couchbase/errors"
 
 module Couchbase
-  class JsonTranscoder
-    # @param [Object] document
+  class RawJsonTranscoder
+    # @param [String] document
     # @return [Array<String, Integer>] pair of encoded document and flags
     def encode(document)
-      raise Error::EncodingFailure, "The JsonTranscoder does not support binary data" if document.is_a?(String) && !document.valid_encoding?
+      raise Error::EncodingFailure, "Only String and binary data supported by RawJsonTranscoder" unless document.is_a?(String)
 
-      [JSON.generate(document), TranscoderFlags.new(format: :json, lower_bits: 6).encode]
+      [document, TranscoderFlags.new(format: :json).encode]
     end
 
     # @param [String] blob string of bytes, containing encoded representation of the document
-    # @param [Integer, :json] flags bit field, describing how the data encoded
-    # @return [Object] decoded document
+    # @param [Integer] flags bit field, describing how the data encoded
+    # @return [String] decoded document
     def decode(blob, flags)
       format = TranscoderFlags.decode(flags).format
-      raise Error::DecodingFailure, "Unable to decode #{format} with the JsonTranscoder" unless format == :json || format.nil?
+      raise Error::DecodingFailure, "Unable to decode #{format} with the RawJsonTranscoder" unless format == :json || format.nil?
 
-      JSON.parse(blob) unless blob&.empty?
+      blob
     end
   end
 end

--- a/lib/couchbase/raw_string_transcoder.rb
+++ b/lib/couchbase/raw_string_transcoder.rb
@@ -1,4 +1,4 @@
-#  Copyright 2020-2021 Couchbase, Inc.
+#  Copyright 2023. Couchbase, Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -12,28 +12,29 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-require "json"
-
 require "couchbase/transcoder_flags"
+require "couchbase/errors"
 
 module Couchbase
-  class JsonTranscoder
-    # @param [Object] document
+  class RawStringTranscoder
+    # @param [String] document
     # @return [Array<String, Integer>] pair of encoded document and flags
     def encode(document)
-      raise Error::EncodingFailure, "The JsonTranscoder does not support binary data" if document.is_a?(String) && !document.valid_encoding?
+      unless document.is_a?(String) && document.valid_encoding?
+        raise Error::EncodingFailure, "Only String data supported by RawStringTranscoder"
+      end
 
-      [JSON.generate(document), TranscoderFlags.new(format: :json, lower_bits: 6).encode]
+      [document, TranscoderFlags.new(format: :string).encode]
     end
 
     # @param [String] blob string of bytes, containing encoded representation of the document
-    # @param [Integer, :json] flags bit field, describing how the data encoded
-    # @return [Object] decoded document
+    # @param [Integer] flags bit field, describing how the data encoded
+    # @return [String] decoded document
     def decode(blob, flags)
       format = TranscoderFlags.decode(flags).format
-      raise Error::DecodingFailure, "Unable to decode #{format} with the JsonTranscoder" unless format == :json || format.nil?
+      raise Error::DecodingFailure, "Unable to decode #{format} with the RawStringTranscoder" unless format == :string || format.nil?
 
-      JSON.parse(blob) unless blob&.empty?
+      blob
     end
   end
 end

--- a/lib/couchbase/transcoder_flags.rb
+++ b/lib/couchbase/transcoder_flags.rb
@@ -1,0 +1,62 @@
+#  Copyright 2023. Couchbase, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+module Couchbase
+  # @api private
+  class TranscoderFlags
+    FORMAT_MAP = {
+      reserved: 0,
+      private: 1,
+      json: 2,
+      binary: 3,
+      string: 4,
+    }.freeze
+    INV_FORMAT_MAP = FORMAT_MAP.invert.freeze
+
+    COMPRESSION_MAP = {none: 0}.freeze
+    INV_COMPRESSION_MAP = COMPRESSION_MAP.invert
+
+    attr_reader :format
+    attr_reader :compression
+    attr_reader :lower_bits
+
+    def initialize(format:, compression: :none, lower_bits: 0)
+      @format = format
+      @compression = compression
+      @lower_bits = lower_bits
+    end
+
+    def self.decode(flags)
+      return TranscoderFlags.new(format: flags) if flags.is_a?(Symbol)
+
+      common_flags = flags >> 24
+      lower_bits = flags & 0x00ffff
+
+      return TranscoderFlags.new(format: nil, lower_bits: lower_bits) if common_flags.zero?
+
+      compression_bits = common_flags >> 5
+      format_bits = common_flags & 0x0f
+      TranscoderFlags.new(
+        format: INV_FORMAT_MAP[format_bits],
+        compression: INV_COMPRESSION_MAP[compression_bits],
+        lower_bits: lower_bits
+      )
+    end
+
+    def encode
+      common_flags = (COMPRESSION_MAP[@compression] << 5) | FORMAT_MAP[@format]
+      (common_flags << 24) | @lower_bits
+    end
+  end
+end

--- a/test/json_transcoder_test.rb
+++ b/test/json_transcoder_test.rb
@@ -1,0 +1,88 @@
+#  Copyright 2023. Couchbase, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+require "test_helper"
+
+require "couchbase/json_transcoder"
+require "couchbase/transcoder_flags"
+require "couchbase/errors"
+
+class JsonTranscoderTest < Minitest::Test
+  include Couchbase::TestUtilities
+
+  def setup
+    @transcoder = Couchbase::JsonTranscoder.new
+  end
+
+  def test_encode_hash
+    document = {:foo => 10, :bar => "baz"}
+    encoded, flag = @transcoder.encode(document)
+
+    assert_equal "{\"foo\":10,\"bar\":\"baz\"}", encoded
+    assert_equal 2, flag >> 24
+  end
+
+  def test_encode_string
+    document = "foo"
+    encoded, flag = @transcoder.encode(document)
+
+    assert_equal "\"foo\"", encoded
+    assert_equal 2, flag >> 24
+  end
+
+  def test_encode_number
+    document = 42
+    encoded, flag = @transcoder.encode(document)
+
+    assert_equal "42", encoded
+    assert_equal 2, flag >> 24
+  end
+
+  def test_encode_binary_fails
+    document = "\x00\xff"
+
+    assert_raises(Couchbase::Error::EncodingFailure) { @transcoder.encode(document) }
+  end
+
+  def test_decode_hash
+    blob = "{\"foo\":10,\"bar\":\"baz\"}"
+    flag = Couchbase::TranscoderFlags.new(format: :json).encode
+    decoded = @transcoder.decode(blob, flag)
+
+    assert_equal({"foo" => 10, "bar" => "baz"}, decoded)
+  end
+
+  def test_decode_string
+    blob = "\"foo\""
+    flag = Couchbase::TranscoderFlags.new(format: :json).encode
+    decoded = @transcoder.decode(blob, flag)
+
+    assert_equal "foo", decoded
+  end
+
+  def test_decode_number
+    blob = "42"
+    flag = Couchbase::TranscoderFlags.new(format: :json).encode
+    decoded = @transcoder.decode(blob, flag)
+
+    assert_equal 42, decoded
+  end
+
+  def test_decode_invalid_flag
+    blob = "\xff\x00"
+    flag = Couchbase::TranscoderFlags.new(format: :binary).encode
+
+    assert_raises(Couchbase::Error::DecodingFailure) { @transcoder.decode(blob, flag) }
+  end
+end

--- a/test/raw_binary_transcoder_test.rb
+++ b/test/raw_binary_transcoder_test.rb
@@ -1,0 +1,58 @@
+#  Copyright 2023. Couchbase, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+require "test_helper"
+
+require "couchbase/raw_binary_transcoder"
+require "couchbase/transcoder_flags"
+require "couchbase/errors"
+
+class RawBinaryTranscoderTest < Minitest::Test
+  include Couchbase::TestUtilities
+
+  def setup
+    @transcoder = Couchbase::RawBinaryTranscoder.new
+  end
+
+  def test_encode_binary
+    document = "\x00\xff"
+
+    encoded, flag = @transcoder.encode(document)
+
+    assert_equal 3, flag >> 24
+    assert_equal "\x00\xff", encoded
+  end
+
+  def test_encode_number
+    document = 42
+
+    assert_raises(Couchbase::Error::EncodingFailure) { @transcoder.encode(document) }
+  end
+
+  def test_decode
+    blob = "\x00\xff"
+    flag = Couchbase::TranscoderFlags.new(format: :binary).encode
+
+    decoded = @transcoder.decode(blob, flag)
+
+    assert_equal "\x00\xff", decoded
+  end
+
+  def test_decode_invalid_flag
+    blob = "foo"
+    flag = Couchbase::TranscoderFlags.new(format: :string).encode
+
+    assert_raises(Couchbase::Error::DecodingFailure) { @transcoder.decode(blob, flag) }
+  end
+end

--- a/test/raw_json_transcoder_test.rb
+++ b/test/raw_json_transcoder_test.rb
@@ -1,0 +1,57 @@
+#  Copyright 2023. Couchbase, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+require "test_helper"
+
+require "couchbase/raw_json_transcoder"
+require "couchbase/transcoder_flags"
+require "couchbase/errors"
+
+class RawJsonTranscoderTest < Minitest::Test
+  include Couchbase::TestUtilities
+
+  def setup
+    @transcoder = Couchbase::RawJsonTranscoder.new
+  end
+
+  def test_encode_string
+    document = "{\"foo\":10,\"bar\":\"baz\"}"
+    encoded, flag = @transcoder.encode(document)
+
+    assert_equal 2, flag >> 24
+    assert_equal "{\"foo\":10,\"bar\":\"baz\"}", encoded
+  end
+
+  def test_encode_number
+    document = 42
+
+    assert_raises(Couchbase::Error::EncodingFailure) { @transcoder.encode(document) }
+  end
+
+  def test_decode
+    blob = "{\"foo\":10,\"bar\":\"baz\"}"
+    flag = Couchbase::TranscoderFlags.new(format: :json).encode
+
+    decoded = @transcoder.decode(blob, flag)
+
+    assert_equal "{\"foo\":10,\"bar\":\"baz\"}", decoded
+  end
+
+  def test_decode_invalid_flag
+    blob = "foo"
+    flag = Couchbase::TranscoderFlags.new(format: :string).encode
+
+    assert_raises(Couchbase::Error::DecodingFailure) { @transcoder.decode(blob, flag) }
+  end
+end

--- a/test/raw_string_transcoder_test.rb
+++ b/test/raw_string_transcoder_test.rb
@@ -1,0 +1,63 @@
+#  Copyright 2023. Couchbase, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+require "test_helper"
+
+require "couchbase/raw_string_transcoder"
+require "couchbase/transcoder_flags"
+require "couchbase/errors"
+
+class RawStringTranscoderTest < Minitest::Test
+  include Couchbase::TestUtilities
+
+  def setup
+    @transcoder = Couchbase::RawStringTranscoder.new
+  end
+
+  def test_encode_string
+    document = "foo"
+    encoded, flag = @transcoder.encode(document)
+
+    assert_equal 4, flag >> 24
+    assert_equal "foo", encoded
+  end
+
+  def test_encode_binary
+    document = "\x00\xff"
+
+    assert_raises(Couchbase::Error::EncodingFailure) { @transcoder.encode(document) }
+  end
+
+  def test_encode_number
+    document = 42
+
+    assert_raises(Couchbase::Error::EncodingFailure) { @transcoder.encode(document) }
+  end
+
+  def test_decode
+    blob = "foo"
+    flag = Couchbase::TranscoderFlags.new(format: :string).encode
+
+    decoded = @transcoder.decode(blob, flag)
+
+    assert_equal "foo", decoded
+  end
+
+  def test_decode_invalid_flag
+    blob = "\xff\x00"
+    flag = Couchbase::TranscoderFlags.new(format: :binary).encode
+
+    assert_raises(Couchbase::Error::DecodingFailure) { @transcoder.decode(blob, flag) }
+  end
+end


### PR DESCRIPTION
* Added `RawJsonTranscoder`, `RawBinaryTranscoder` and `RawStringTranscoder`
* Added the `TranscoderFlags` to handle the encoding and decoding of flags
* Added tests for the `JsonTranscoder` and the newly added transcoders
* Added check to the `JsonTranscoder` to ensure that if string data is provided it has a valid encoding
* Added check to the `JsonTranscoder` to ensure that the flag has the format set as json