### PR TITLE
RCBC-426: Use the default timeouts set in the cluster options

### DIFF
--- a/lib/couchbase/protostellar/cluster.rb
+++ b/lib/couchbase/protostellar/cluster.rb
@@ -17,6 +17,7 @@
 require_relative "connect_options"
 require_relative "bucket"
 require_relative "client"
+require_relative "timeouts"
 require_relative "management/bucket_manager"
 require_relative "request_generator/query"
 require_relative "request_generator/search"
@@ -32,7 +33,8 @@ module Couchbase
 
       def self.connect(connection_string, options = Couchbase::Options::Cluster.new)
         connect_options = ConnectOptions.new(username: options.authenticator.username,
-                                             password: options.authenticator.password)
+                                             password: options.authenticator.password,
+                                             timeouts: Protostellar::Timeouts.from_cluster_options(options))
         Cluster.new(connection_string.split("://")[1], connect_options)
       end
 
@@ -41,8 +43,9 @@ module Couchbase
         credentials = options.grpc_credentials
         channel_args = options.grpc_channel_args
         call_metadata = options.grpc_call_metadata
+        timeouts = options.timeouts
 
-        @client = Client.new(host, credentials, channel_args, call_metadata)
+        @client = Client.new(host, credentials, channel_args, call_metadata, timeouts)
         @query_request_generator = RequestGenerator::Query.new
         @search_request_generator = RequestGenerator::Search.new
       end

--- a/lib/couchbase/protostellar/connect_options.rb
+++ b/lib/couchbase/protostellar/connect_options.rb
@@ -16,10 +16,15 @@
 
 require "base64"
 
+require_relative "timeouts"
+
 module Couchbase
   module Protostellar
     class ConnectOptions
-      def initialize(username: nil, password: nil, root_certificates: nil, client_certificate: nil, private_key: nil)
+      attr_reader :timeouts
+
+      def initialize(timeouts: Timeouts.new, username: nil, password: nil, root_certificates: nil, client_certificate: nil, private_key: nil)
+        @timeouts = timeouts
         @username = username
         @password = password
         @root_certificates = root_certificates

--- a/lib/couchbase/protostellar/request.rb
+++ b/lib/couchbase/protostellar/request.rb
@@ -66,6 +66,12 @@ module Couchbase
       def error_context
         @context.merge({retry_reasons: @retry_reasons.to_a, retry_attempts: @retry_attempts})
       end
+
+      def set_timeout_from_defaults(timeouts)
+        return unless @timeout.nil?
+
+        @timeout = timeouts.timeout_for_service(@service)
+      end
     end
   end
 end

--- a/lib/couchbase/protostellar/request_generator/admin/bucket.rb
+++ b/lib/couchbase/protostellar/request_generator/admin/bucket.rb
@@ -15,7 +15,6 @@
 #  limitations under the License.
 
 require_relative "../../request"
-require_relative "../../timeout_defaults"
 require_relative "../../generated/admin/bucket/v1/bucket_pb"
 require_relative "../kv"
 
@@ -56,11 +55,6 @@ module Couchbase
 
           DURABILITY_LEVEL_MAP = RequestGenerator::KV::DURABILITY_LEVEL_MAP
 
-          attr_reader :default_timeout
-
-          def initialize(default_timeout: nil)
-            @default_timeout = default_timeout.nil? ? TimeoutDefaults::MANAGEMENT : default_timeout
-          end
 
           def list_buckets_request(options)
             proto_req = Generated::Admin::Bucket::V1::ListBucketsRequest.new
@@ -107,21 +101,13 @@ module Couchbase
           end
 
           def create_request(proto_request, rpc, options, idempotent: false)
-            req = Request.new(
+            Request.new(
               service: :bucket_admin,
               rpc: rpc,
               proto_request: proto_request,
               idempotent: idempotent,
-              timeout: get_timeout(options)
+              timeout: options.timeout
             )
-          end
-
-          def get_timeout(options)
-            if options.timeout.nil?
-              @default_timeout
-            else
-              options.timeout
-            end
           end
         end
       end

--- a/lib/couchbase/protostellar/request_generator/admin/collection.rb
+++ b/lib/couchbase/protostellar/request_generator/admin/collection.rb
@@ -23,13 +23,9 @@ module Couchbase
       module Admin
         class Collection
           attr_reader :client
-          attr_reader :default_timeout
 
-          def initialize(bucket_name:, default_timeout: nil)
+          def initialize(bucket_name:)
             @bucket_name = bucket_name
-
-            # TODO: Use the management timeout from the cluster's options
-            @default_timeout = default_timeout.nil? ? TimeoutDefaults::MANAGEMENT : default_timeout
           end
 
           def list_collections_request(options)
@@ -80,21 +76,13 @@ module Couchbase
           private
 
           def create_request(proto_request, rpc, options, idempotent: false)
-            req = Request.new(
+            Request.new(
               service: :collection_admin,
               rpc: rpc,
               proto_request: proto_request,
               idempotent: idempotent,
-              timeout: get_timeout(options)
+              timeout: options.timeout
             )
-          end
-
-          def get_timeout(options)
-            if options.timeout.nil?
-              @default_timeout
-            else
-              options.timeout
-            end
           end
         end
       end

--- a/lib/couchbase/protostellar/request_generator/kv.rb
+++ b/lib/couchbase/protostellar/request_generator/kv.rb
@@ -20,7 +20,6 @@ require "couchbase/errors"
 
 require "couchbase/protostellar/generated/kv/v1/kv_pb"
 require "couchbase/protostellar/request"
-require "couchbase/protostellar/timeout_defaults"
 
 require "google/protobuf/well_known_types"
 
@@ -64,15 +63,11 @@ module Couchbase
         attr_reader :bucket_name
         attr_reader :scope_name
         attr_reader :collection_name
-        attr_reader :default_timeout
 
-        def initialize(bucket_name, scope_name, collection_name, default_timeout = nil)
+        def initialize(bucket_name, scope_name, collection_name)
           @bucket_name = bucket_name
           @scope_name = scope_name
           @collection_name = collection_name
-
-          # TODO: Use the KV timeout from the cluster's options
-          @default_timeout = default_timeout.nil? ? TimeoutDefaults::KEY_VALUE : default_timeout
         end
 
         def location
@@ -337,7 +332,7 @@ module Couchbase
             service: :kv,
             rpc: rpc,
             proto_request: proto_request,
-            timeout: get_timeout(options),
+            timeout: options.timeout,
             idempotent: idempotent
           )
         end
@@ -435,14 +430,6 @@ module Couchbase
             encoded, flag = options.transcoder.encode(content)
           end
           [encoded, flag]
-        end
-
-        def get_timeout(options)
-          if options.timeout.nil?
-            @default_timeout
-          else
-            options.timeout
-          end
         end
       end
     end

--- a/lib/couchbase/protostellar/request_generator/query.rb
+++ b/lib/couchbase/protostellar/request_generator/query.rb
@@ -37,10 +37,9 @@ module Couchbase
         attr_reader :bucket_name
         attr_reader :scope_name
 
-        def initialize(bucket_name: nil, scope_name: nil, default_timeout: nil)
+        def initialize(bucket_name: nil, scope_name: nil)
           @bucket_name = bucket_name
           @scope_name = scope_name
-          @default_timeout = default_timeout.nil? ? TimeoutDefaults::QUERY : default_timeout
         end
 
         def query_request(statement, options)
@@ -88,7 +87,7 @@ module Couchbase
             service: :query,
             rpc: rpc,
             proto_request: proto_request,
-            timeout: get_timeout(options),
+            timeout: options.timeout,
             idempotent: idempotent
           )
         end
@@ -109,14 +108,6 @@ module Couchbase
             nil
           else
             Generated::Query::V1::QueryRequest::TuningOptions.new(**tuning_opts)
-          end
-        end
-
-        def get_timeout(options)
-          if options.timeout.nil?
-            @default_timeout
-          else
-            options.timeout
           end
         end
       end

--- a/lib/couchbase/protostellar/request_generator/search.rb
+++ b/lib/couchbase/protostellar/request_generator/search.rb
@@ -1,5 +1,19 @@
 # frozen_string_literal: true
 
+#  Copyright 2023. Couchbase, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 require "google/protobuf/well_known_types"
 
 require "couchbase/search_options"
@@ -25,10 +39,6 @@ module Couchbase
         SCAN_CONSISTENCY_MAP = {
           :not_bounded => :SCAN_CONSISTENCY_NOT_BOUNDED,
         }.freeze
-
-        def initialize(default_timeout: nil)
-          @default_timeout = default_timeout.nil? ? TimeoutDefaults::SEARCH : default_timeout
-        end
 
         def search_query_request(index_name, query, options)
           proto_opts = {
@@ -62,7 +72,7 @@ module Couchbase
             service: :search,
             rpc: rpc,
             proto_request: proto_request,
-            timeout: get_timeout(options),
+            timeout: options.timeout,
             idempotent: idempotent
           )
         end
@@ -323,14 +333,6 @@ module Couchbase
             else
               raise Protostellar::Error::ProtostellarError, "Unrecognised search sort type"
             end
-          end
-        end
-
-        def get_timeout(options)
-          if options.timeout.nil?
-            @default_timeout
-          else
-            options.timeout
           end
         end
       end

--- a/lib/couchbase/protostellar/timeouts.rb
+++ b/lib/couchbase/protostellar/timeouts.rb
@@ -34,12 +34,12 @@ module Couchbase
         search_timeout: nil,
         management_timeout: nil
       )
-        @key_value_timeout = key_value_timeout.nil? ? TimeoutDefaults::KEY_VALUE : key_value_timeout
-        @view_timeout = view_timeout.nil? ? TimeoutDefaults::VIEW : view_timeout
-        @query_timeout = query_timeout.nil? ? TimeoutDefaults::QUERY : query_timeout
-        @analytics_timeout = analytics_timeout.nil? ? TimeoutDefaults::ANALYTICS : analytics_timeout
-        @search_timeout = search_timeout.nil? ? TimeoutDefaults::SEARCH : search_timeout
-        @management_timeout = management_timeout.nil? ? TimeoutDefaults::MANAGEMENT : management_timeout
+        @key_value_timeout = key_value_timeout || TimeoutDefaults::KEY_VALUE
+        @view_timeout = view_timeout || TimeoutDefaults::VIEW
+        @query_timeout = query_timeout || TimeoutDefaults::QUERY
+        @analytics_timeout = analytics_timeout || TimeoutDefaults::ANALYTICS
+        @search_timeout = search_timeout || TimeoutDefaults::SEARCH
+        @management_timeout = management_timeout || TimeoutDefaults::MANAGEMENT
       end
 
       def timeout_for_service(service)
@@ -56,6 +56,8 @@ module Couchbase
           @view_timeout
         when :bucket_admin, :collection_admin
           @management_timeout
+        else
+          raise Protostellar::Error::UnexpectedServiceType, "Service #{service} not recognised"
         end
       end
 

--- a/lib/couchbase/protostellar/timeouts.rb
+++ b/lib/couchbase/protostellar/timeouts.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require_relative "timeout_defaults"
+
+module Couchbase
+  module Protostellar
+    class Timeouts
+      attr_reader :key_value_timeout
+      attr_reader :view_timeout
+      attr_reader :query_timeout
+      attr_reader :analytics_timeout
+      attr_reader :search_timeout
+      attr_reader :management_timeout
+
+      def initialize(
+        key_value_timeout: nil,
+        view_timeout: nil,
+        query_timeout: nil,
+        analytics_timeout: nil,
+        search_timeout: nil,
+        management_timeout: nil
+      )
+        @key_value_timeout = key_value_timeout.nil? ? TimeoutDefaults::KEY_VALUE : key_value_timeout
+        @view_timeout = view_timeout.nil? ? TimeoutDefaults::VIEW : view_timeout
+        @query_timeout = query_timeout.nil? ? TimeoutDefaults::QUERY : query_timeout
+        @analytics_timeout = analytics_timeout.nil? ? TimeoutDefaults::ANALYTICS : analytics_timeout
+        @search_timeout = search_timeout.nil? ? TimeoutDefaults::SEARCH : search_timeout
+        @management_timeout = management_timeout.nil? ? TimeoutDefaults::MANAGEMENT : management_timeout
+      end
+
+      def timeout_for_service(service)
+        if service == :analytics
+          @analytics_timeout
+        elsif service == :kv
+          @key_value_timeout
+        elsif service == :query
+          @query_timeout
+        elsif service == :search
+          @search_timeout
+        elsif service == :view
+          @view_timeout
+        elsif [:bucket_admin, :collection_admin].include? service
+          @management_timeout
+        end
+      end
+
+      def self.from_cluster_options(options)
+        Timeouts.new(
+          key_value_timeout: options.key_value_timeout,
+          view_timeout: options.view_timeout,
+          query_timeout: options.query_timeout,
+          analytics_timeout: options.analytics_timeout,
+          search_timeout: options.search_timeout,
+          management_timeout: options.management_timeout
+        )
+      end
+    end
+  end
+end

--- a/lib/couchbase/protostellar/timeouts.rb
+++ b/lib/couchbase/protostellar/timeouts.rb
@@ -1,5 +1,19 @@
 # frozen_string_literal: true
 
+#  Copyright 2023. Couchbase, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 require_relative "timeout_defaults"
 
 module Couchbase

--- a/lib/couchbase/protostellar/timeouts.rb
+++ b/lib/couchbase/protostellar/timeouts.rb
@@ -43,17 +43,18 @@ module Couchbase
       end
 
       def timeout_for_service(service)
-        if service == :analytics
+        case service
+        when :analytics
           @analytics_timeout
-        elsif service == :kv
+        when :kv
           @key_value_timeout
-        elsif service == :query
+        when :query
           @query_timeout
-        elsif service == :search
+        when :search
           @search_timeout
-        elsif service == :view
+        when :view
           @view_timeout
-        elsif [:bucket_admin, :collection_admin].include? service
+        when :bucket_admin, :collection_admin
           @management_timeout
         end
       end

--- a/sig/couchbase/protostellar/client.rbs
+++ b/sig/couchbase/protostellar/client.rbs
@@ -16,6 +16,9 @@ module Couchbase
   module Protostellar
     class Client
       @channel: Object
+      @call_metadata: Hash[untyped, untyped]
+      @timeouts: Timeouts
+
       @routing_stub: Object
       @kv_stub: Object
       @query_stub: Object
@@ -25,7 +28,7 @@ module Couchbase
       @bucket_admin_stub: Object
       @collection_admin_stub: Object
 
-      def initialize: (String host, untyped credentials, untyped channel_args) -> void
+      def initialize: (String host, untyped credentials, untyped channel_args, Hash[untyped, untyped] call_metadata, Timeouts timeouts) -> void
       def stub: (Symbol) -> untyped
       def send_request: (Request) -> untyped
       def close: () -> void

--- a/sig/couchbase/protostellar/connect_options.rbs
+++ b/sig/couchbase/protostellar/connect_options.rbs
@@ -21,12 +21,10 @@ module Couchbase
       @root_certificates: String?
       @username: String?
 
-      def initialize: (?username: String? username, ?password: String? password, ?root_certificates: String? root_certificates, ?client_certificate: String? client_certificate, ?private_key: String? private_key) -> void
+      def initialize: (?timeouts: Timeouts, ?username: String? username, ?password: String? password, ?root_certificates: String? root_certificates, ?client_certificate: String? client_certificate, ?private_key: String? private_key) -> void
 
       def grpc_credentials: () -> untyped
-
       def grpc_channel_args: () -> untyped
-
       def grpc_call_metadata: () -> Hash[untyped, untyped]
     end
   end

--- a/sig/couchbase/protostellar/request.rbs
+++ b/sig/couchbase/protostellar/request.rbs
@@ -40,6 +40,7 @@ module Couchbase
       def deadline: () -> untyped
       def add_retry_attempt: (Retry::Reason) -> void
       def error_context: () -> Hash[Symbol, any]
+      def set_timeout_from_defaults: (Timeouts timeouts) -> void
     end
   end
 end

--- a/sig/couchbase/protostellar/request_generator/admin/bucket.rbs
+++ b/sig/couchbase/protostellar/request_generator/admin/bucket.rbs
@@ -24,12 +24,6 @@ module Couchbase
           CONFLICT_RESOLUTION_TYPE_MAP: Hash[Symbol, Symbol]
           DURABILITY_LEVEL_MAP: Hash[Symbol, Symbol]
 
-          attr_reader default_timeout: _CanInMilliseconds | Integer
-
-          def initialize: (
-              default_timeout: (_CanInMilliseconds | Integer)?,
-            ) -> void
-
           def list_buckets_request: (untyped options) -> untyped
           def create_bucket_request: (untyped settings, untyped options) -> untyped
           def update_bucket_request: (untyped settings, untyped options) -> untyped
@@ -45,8 +39,6 @@ module Couchbase
               untyped options,
               idempotent: bool,
             ) -> Request
-
-          def get_timeout: (untyped options) -> (_CanInMilliseconds | Integer)
         end
       end
     end

--- a/sig/couchbase/protostellar/request_generator/admin/collection.rbs
+++ b/sig/couchbase/protostellar/request_generator/admin/collection.rbs
@@ -18,11 +18,9 @@ module Couchbase
       module Admin
         class Collection
           attr_reader client: Client
-          attr_reader default_timeout: _CanInMilliseconds | Integer
 
           def initialize: (
               bucket_name: String,
-              default_timeout: (_CanInMilliseconds | Integer)?,
             ) -> void
 
           def list_collections_request: (untyped options) -> untyped
@@ -39,8 +37,6 @@ module Couchbase
               untyped options,
               idempotent: bool,
             ) -> Request
-
-          def get_timeout: (untyped options) -> (_CanInMilliseconds | Integer)
         end
       end
     end

--- a/sig/couchbase/protostellar/request_generator/kv.rbs
+++ b/sig/couchbase/protostellar/request_generator/kv.rbs
@@ -24,9 +24,8 @@ module Couchbase
         attr_reader bucket_name: String
         attr_reader scope_name: String
         attr_reader collection_name: String
-        attr_reader default_timeout: _CanInMilliseconds | Integer
 
-        def initialize: (String, String, String, (_CanInMilliseconds | Integer)?) -> void
+        def initialize: (String, String, String) -> void
 
         def location: () -> Hash[Symbol, String]
 
@@ -63,7 +62,6 @@ module Couchbase
         def get_mutate_in_flags: (untyped) -> untyped
         def get_mutate_in_store_semantic: (untyped) -> Symbol
         def get_encoded: (Object, untyped) -> [String, Integer]
-        def get_timeout: (untyped) -> (_CanInMilliseconds | Integer)
       end
     end
   end

--- a/sig/couchbase/protostellar/request_generator/query.rbs
+++ b/sig/couchbase/protostellar/request_generator/query.rbs
@@ -21,12 +21,10 @@ module Couchbase
 
         attr_reader bucket_name: String
         attr_reader scope_name: String
-        attr_reader default_timeout: _CanInMilliseconds | Integer
 
         def initialize: (
             bucket_name: String?,
             scope_name: String?,
-            default_timeout: (_CanInMilliseconds | Integer)?
           ) -> void
 
         def query_request: (String, untyped) -> untyped
@@ -35,7 +33,6 @@ module Couchbase
 
         def create_query_request: (untyped, Symbol, untyped, idempotent: bool) -> untyped
         def create_tuning_options: (untyped) -> untyped
-        def get_timeout: (untyped) -> (_CanInMilliseconds | Integer)
       end
     end
   end

--- a/sig/couchbase/protostellar/request_generator/search.rbs
+++ b/sig/couchbase/protostellar/request_generator/search.rbs
@@ -6,9 +6,6 @@ module Couchbase
         HIGHLIGHT_STYLE_MAP: Hash[Symbol?, Symbol]
         SCAN_CONSISTENCY_MAP: Hash[Symbol, Symbol]
 
-        @default_timeout: _CanInMilliseconds | Integer
-
-        def initialize: (default_timeout: (_CanInMilliseconds | Integer)?) -> void
         def search_query_request: (String index_name, untyped query, untyped options) -> untyped
 
         private
@@ -44,7 +41,6 @@ module Couchbase
         def create_wildcard_query: (untyped query) -> untyped
 
         def get_sort: (untyped options) -> untyped
-        def get_timeout: (untyped options) -> (_CanInMilliseconds | Integer)
       end
     end
   end

--- a/sig/couchbase/protostellar/timeouts.rbs
+++ b/sig/couchbase/protostellar/timeouts.rbs
@@ -1,3 +1,17 @@
+#  Copyright 2023. Couchbase, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 module Couchbase
   module Protostellar
     class Timeouts

--- a/sig/couchbase/protostellar/timeouts.rbs
+++ b/sig/couchbase/protostellar/timeouts.rbs
@@ -1,0 +1,25 @@
+module Couchbase
+  module Protostellar
+    class Timeouts
+      attr_reader key_value_timeout: _CanInMilliseconds | Integer
+      attr_reader view_timeout: _CanInMilliseconds | Integer
+      attr_reader query_timeout: _CanInMilliseconds | Integer
+      attr_reader analytics_timeout: _CanInMilliseconds | Integer
+      attr_reader search_timeout: _CanInMilliseconds | Integer
+      attr_reader management_timeout: _CanInMilliseconds | Integer
+
+      def initialize: (
+          key_value_timeout: (_CanInMilliseconds | Integer)?,
+          view_timeout: (_CanInMilliseconds | Integer)?,
+          query_timeout: (_CanInMilliseconds | Integer)?,
+          analytics_timeout: (_CanInMilliseconds | Integer)?,
+          search_timeout: (_CanInMilliseconds | Integer)?,
+          management_timeout: (_CanInMilliseconds | Integer)?
+        ) -> void
+
+      def timeout_for_service: (Symbol service) -> (_CanInMilliseconds | Integer)
+
+      def self.from_cluster_options: (Couchbase::Options::Cluster options) -> Timeouts
+    end
+  end
+end

--- a/spec/couchbase/protostellar/timeouts_spec.rb
+++ b/spec/couchbase/protostellar/timeouts_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+#  Copyright 2023. Couchbase, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+require "rspec"
+
+require "couchbase/options"
+require "couchbase/protostellar/timeouts"
+require "couchbase/protostellar/timeout_defaults"
+
+RSpec.describe Couchbase::Protostellar::Timeouts do
+  let(:example_timeout_values) do
+    {
+      key_value_timeout: 10_000,
+      view_timeout: 11_000,
+      query_timeout: 12_000,
+      analytics_timeout: 13_000,
+      search_timeout: 14_000,
+      management_timeout: 15_000,
+    }
+  end
+
+  let(:default_timeout_values) do
+    {
+      key_value_timeout: Couchbase::Protostellar::TimeoutDefaults::KEY_VALUE,
+      view_timeout: Couchbase::Protostellar::TimeoutDefaults::VIEW,
+      query_timeout: Couchbase::Protostellar::TimeoutDefaults::QUERY,
+      analytics_timeout: Couchbase::Protostellar::TimeoutDefaults::ANALYTICS,
+      search_timeout: Couchbase::Protostellar::TimeoutDefaults::SEARCH,
+      management_timeout: Couchbase::Protostellar::TimeoutDefaults::MANAGEMENT,
+    }
+  end
+
+  describe ".from_cluster_options" do
+    context "when the timeouts are set in the cluster options" do
+      subject(:timeouts) do
+        described_class.from_cluster_options(options)
+      end
+
+      let(:options) do
+        Couchbase::Options::Cluster.new(**example_timeout_values)
+      end
+
+      it "returns a Timeouts instance with the timeout values from the cluster options" do
+        expect(timeouts).to have_attributes(**example_timeout_values)
+      end
+    end
+
+    context "when none of the timeouts are set in the cluster options" do
+      subject(:timeouts) do
+        described_class.from_cluster_options(Couchbase::Options::Cluster.new)
+      end
+
+      it "returns a Timeouts instance with the default timeouts" do
+        expect(timeouts).to have_attributes(**default_timeout_values)
+      end
+    end
+  end
+
+  describe "#timeout_for_service" do
+    subject(:timeouts) do
+      described_class.new(**example_timeout_values)
+    end
+
+    services = [:analytics, :kv, :query, :search, :view, :bucket_admin, :collection_admin]
+    expected_timeouts = [13_000, 10_000, 12_000, 14_000, 11_000, 15_000, 15_000]
+
+    services.zip(expected_timeouts).each do |service, exp_timeout|
+      it "returns the correct timeout for the #{service} service" do
+        expect(timeouts.timeout_for_service(service)).to be exp_timeout
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Added `Timeouts` class which holds the global timeouts (either the ones that are defined in the cluster options or the defaults if they are not set in the cluster options)
* The timeouts are passed on to the `Client` which fills in the timeout in the request before sending it with the default value if it's not already defined
* Added some unit tests for the `Timeouts` class