### PR TITLE
RCBC-437: Update error mappings to include any recent additions

### DIFF
--- a/spec/support/shared_examples/collection_subdoc.rb
+++ b/spec/support/shared_examples/collection_subdoc.rb
@@ -376,7 +376,7 @@ RSpec.shared_examples "collection sub-document operations" do
       end
     end
 
-    context "withg multiple operations including a counter increment" do
+    context "with multiple operations including a counter increment" do
       let(:doc_id) do
         upsert_sample_document(content: {
           "mutated" => 0,


### PR DESCRIPTION
* Handling more types of GRPC status
* Tidy up the stub variables in `Protostellar::Client`
* Use the error message from the GRPC status