### PR TITLE
Bug fixes & small improvements

### DIFF
--- a/lib/couchbase/protostellar/error_handling.rb
+++ b/lib/couchbase/protostellar/error_handling.rb
@@ -114,12 +114,22 @@ module Couchbase
 
         when GRPC::NotFound
           case detail_block[:resource_info].resource_type
-          when "collection"
-            RequestBehaviour.fail(Couchbase::Error::CollectionNotFound.new(message, request.error_context))
           when "bucket"
             RequestBehaviour.fail(Couchbase::Error::BucketNotFound.new(message, request.error_context))
           when "scope"
             RequestBehaviour.fail(Couchbase::Error::ScopeNotFound.new(message, request.error_context))
+          when "collection"
+            RequestBehaviour.fail(Couchbase::Error::CollectionNotFound.new(message, request.error_context))
+          end
+
+        when GRPC::AlreadyExists
+          case detail_block[:resource_info].resource_type
+          when "bucket"
+            RequestBehaviour.fail(Couchbase::Error::BucketExists.new(message, request.error_context))
+          when "scope"
+            RequestBehaviour.fail(Couchbase::Error::ScopeExists.new(message, request.error_context))
+          when "collection"
+            RequestBehaviour.fail(Couchbase::Error::CollectionExists.new(message, request.error_context))
           end
 
         when GRPC::PermissionDenied, GRPC::Unauthenticated

--- a/lib/couchbase/protostellar/management/collection_query_index_manager.rb
+++ b/lib/couchbase/protostellar/management/collection_query_index_manager.rb
@@ -106,12 +106,12 @@ module Couchbase
 
         def validate_options(options)
           unless options.scope_name.nil?
-            raise Error::InvalidArgument,
+            raise Couchbase::Error::InvalidArgument,
                   "Scope name cannot be set in the options when using the Query Index manager at the collection level"
           end
 
           unless options.collection_name.nil?
-            raise Error::InvalidArgument,
+            raise Couchbase::Error::InvalidArgument,
                   "Collection name cannot be set in the options when using the Query Index manager at the collection level"
           end
         end

--- a/lib/couchbase/protostellar/request_generator/admin/query.rb
+++ b/lib/couchbase/protostellar/request_generator/admin/query.rb
@@ -30,7 +30,9 @@ module Couchbase
 
           def get_all_indexes_request(options, bucket_name = nil)
             proto_req = Generated::Admin::Query::V1::GetAllIndexesRequest.new(
-              **location(bucket_name: bucket_name)
+              **location(
+                bucket_name: bucket_name, scope_name: options.scope_name, collection_name: options.collection_name
+              )
             )
 
             create_request(proto_req, :get_all_indexes, options, idempotent: true)
@@ -40,10 +42,13 @@ module Couchbase
             proto_opts = {
               deferred: options.deferred,
             }
+            proto_opts[:name] = options.index_name unless options.index_name.nil?
             proto_opts[:num_replicas] = options.num_replicas unless options.num_replicas.nil?
 
             proto_req = Generated::Admin::Query::V1::CreatePrimaryIndexRequest.new(
-              **location(bucket_name: bucket_name),
+              **location(
+                bucket_name: bucket_name, scope_name: options.scope_name, collection_name: options.collection_name
+              ),
               **proto_opts
             )
 
@@ -57,7 +62,9 @@ module Couchbase
             proto_opts[:num_replicas] = options.num_replicas unless options.num_replicas.nil?
 
             proto_req = Generated::Admin::Query::V1::CreateIndexRequest.new(
-              **location(bucket_name: bucket_name),
+              **location(
+                bucket_name: bucket_name, scope_name: options.scope_name, collection_name: options.collection_name
+              ),
               name: index_name,
               fields: fields,
               **proto_opts
@@ -68,7 +75,9 @@ module Couchbase
 
           def drop_primary_index_request(options, bucket_name = nil)
             proto_req = Generated::Admin::Query::V1::DropPrimaryIndexRequest.new(
-              **location(bucket_name: bucket_name)
+              **location(
+                bucket_name: bucket_name, scope_name: options.scope_name, collection_name: options.collection_name
+              )
             )
 
             create_request(proto_req, :drop_primary_index, options)
@@ -76,7 +85,9 @@ module Couchbase
 
           def drop_index_request(index_name, options, bucket_name = nil)
             proto_req = Generated::Admin::Query::V1::DropIndexRequest.new(
-              **location(bucket_name: bucket_name),
+              **location(
+                bucket_name: bucket_name, scope_name: options.scope_name, collection_name: options.collection_name
+              ),
               name: index_name
             )
 
@@ -85,7 +96,9 @@ module Couchbase
 
           def build_deferred_indexes_request(options, bucket_name = nil)
             proto_req = Generated::Admin::Query::V1::BuildDeferredIndexesRequest.new(
-              **location(bucket_name: bucket_name)
+              **location(
+                bucket_name: bucket_name, scope_name: options.scope_name, collection_name: options.collection_name
+              )
             )
 
             create_request(proto_req, :build_deferred_indexes, options)
@@ -93,11 +106,11 @@ module Couchbase
 
           private
 
-          def location(bucket_name: nil)
+          def location(bucket_name: nil, scope_name: nil, collection_name: nil)
             {
-              bucket_name: bucket_name || @bucket_name,
-              scope_name: @scope_name,
-              collection_name: @collection_name,
+              bucket_name: @bucket_name || bucket_name,
+              scope_name: @scope_name || scope_name,
+              collection_name: @collection_name || collection_name,
             }.compact
           end
 

--- a/lib/couchbase/protostellar/response_converter/admin/query.rb
+++ b/lib/couchbase/protostellar/response_converter/admin/query.rb
@@ -39,6 +39,9 @@ module Couchbase
           def self.to_query_index_array(resp)
             resp.indexes.map do |proto_idx|
               Couchbase::Management::QueryIndex.new do |idx|
+                idx.bucket = proto_idx.bucket_name
+                idx.scope = proto_idx.scope_name
+                idx.collection = proto_idx.collection_name
                 idx.name = proto_idx.name
                 idx.is_primary = proto_idx.is_primary
                 idx.type = INDEX_TYPE_MAP[proto_idx.type]


### PR DESCRIPTION
* Added `ScopeExists`, `BucketExists` & `CollectionExists` in error map
* Fixed `NameError` when trying to raise an `Error::InvalidArgument`
* Add `scope_name` and `collection_name` from the options to query index management requests
* Include bucket/scope/collection names in result for `get_all_indexes`