### PR TITLE
Fix what appears to be a huge mistake in extract_duration

### DIFF
--- a/lib/couchbase/utils/time.rb
+++ b/lib/couchbase/utils/time.rb
@@ -49,7 +49,7 @@ module Couchbase
       end
 
       def extract_duration(number_or_duration)
-        number_or_duration.respond_to?(:in_milliseconds) ? number_or_duration.public_send(:in_milliseconds) : number_or_duration
+        number_or_duration
       end
     end
   end


### PR DESCRIPTION
Currently, `Utils::Time.extract_duration` checks to see if the value you passed in responds to `in_milliseconds`, and if it does, it calls that method and uses that result for the timeout.

This is **_insane_**...

It means that if you are in a non-rails environment and are using couch, you can specify timeouts with a granularity of as little as 1 millisecond.  But if you are in rails, you're basically screwed, and cannot specify anything less than 1 second.

```ruby
1.in_milliseconds
> 1000
```

You can't use floats, because if you do you get this error: `timeout must be an Integer, but given "0.001"`.  Likewise, you can't specify a string or you'll get a similar error.

I would have opened a simple issue in github, but you've disabled that for the repo.  I would have entered a ticket in your Jira but the username and pass I have isn't working and the forgot password isn't either.

So while I don't expect you to actually accept this PR, please, please, _please_ fix this issue.