### PR TITLE
update core to 1.0.0-dp.7

### DIFF
--- a/ext/couchbase.cxx
+++ b/ext/couchbase.cxx
@@ -8873,6 +8873,16 @@ cb_Backend_form_encode(VALUE self, VALUE data)
     return cb_str_new(encoded);
 }
 
+static VALUE
+cb_Backend_enable_protocol_logger_to_save_network_traffic_to_file(VALUE /* self */, VALUE path)
+{
+    Check_Type(path, T_STRING);
+    couchbase::core::logger::configuration configuration{};
+    configuration.filename = cb_string_new(path);
+    couchbase::core::logger::create_protocol_logger(configuration);
+    return Qnil;
+}
+
 static void
 init_backend(VALUE mCouchbase)
 {
@@ -9003,6 +9013,10 @@ init_backend(VALUE mCouchbase)
     rb_define_singleton_method(cBackend, "query_escape", VALUE_FUNC(cb_Backend_query_escape), 1);
     rb_define_singleton_method(cBackend, "path_escape", VALUE_FUNC(cb_Backend_path_escape), 1);
     rb_define_singleton_method(cBackend, "form_encode", VALUE_FUNC(cb_Backend_form_encode), 1);
+    rb_define_singleton_method(cBackend,
+                               "enable_protocol_logger_to_save_network_traffic_to_file",
+                               VALUE_FUNC(cb_Backend_enable_protocol_logger_to_save_network_traffic_to_file),
+                               1);
 }
 
 void


### PR DESCRIPTION
Protocol logger could be enabled like this:

    Couchbase::Backend.enable_protocol_logger_to_save_network_traffic_to_file("/tmp/cb.log")

Then all the logs will be recorded (and rotated automatically):

    $ ls -1 /tmp/cb.log*
    /tmp/cb.log.000000.txt

    $ head /tmp/cb.log.000000.txt
    [2023-07-26 13:59:17.107] [618461,0] [info] 0ms, ---------- Opening logfile: /tmp/cb.log.000000.txt
    [2023-07-26 13:59:40.453] [618461,619134] [trace] 23345ms, [MCBP, OUT] host="127.0.0.1", port=12000, buffer_size=220
    0000: 80 1f 00 a4 00 00 00 00 00 00 00 c4 00 00 00 01 00 00 00 00 00 00 00 00 7b 22 61 22 3a 22 63 78  ........................{"a":"cx
    0020: 78 2f 31 2e 30 2e 30 2f 33 34 31 65 30 31 62 3b 4c 69 6e 75 78 2f 78 38 36 5f 36 34 3b 72 75 62  x/1.0.0/341e01b;Linux/x86_64;rub
    0040: 79 5f 73 64 6b 2f 62 35 33 35 39 32 37 31 3b 73 73 6c 2f 33 30 30 30 30 30 39 30 3b 72 75 62 79  y_sdk/b5359271;ssl/30000090;ruby

Notable changes:
* CXXCBC-346: allow to log network communication (#425)
* CXXCBC-350: Resolve collection ID before performing any scan operations (#433)