### PR TITLE
RCBC-443: Support for Subdocument Read from Replica

### DIFF
--- a/lib/couchbase/collection.rb
+++ b/lib/couchbase/collection.rb
@@ -523,7 +523,7 @@ module Couchbase
     #
     # @return [Array<LookupInReplicaResult>]
     #
-    # @raise [Error::DocumentIrretrievable]
+    # @raise [Error::DocumentNotFound]
     # @raise [Error::Timeout]
     # @raise [Error::CouchbaseError]
     # @raise [Error::FeatureNotAvailable]

--- a/lib/couchbase/collection_options.rb
+++ b/lib/couchbase/collection_options.rb
@@ -230,6 +230,18 @@ module Couchbase
       end
     end
 
+    class LookupInReplicaResult < LookupInResult
+      # @return [Boolean] true if the document was read from a replica node
+      attr_accessor :is_replica
+      alias replica? is_replica
+
+      # @yieldparam [LookupInReplicaResult] self
+      def initialize
+        super
+        yield self if block_given?
+      end
+    end
+
     class MutateInResult < MutationResult
       # Decodes the content at the given index
       #

--- a/lib/couchbase/options.rb
+++ b/lib/couchbase/options.rb
@@ -1026,6 +1026,80 @@ module Couchbase
       DEFAULT = LookupIn.new.freeze
     end
 
+    # Options for {Collection#lookup_in_any_replica}
+    class LookupInAnyReplica < Base
+      attr_accessor :transcoder # @return [JsonTranscoder, #decode(String)]
+
+      # Creates an instance of options for {Collection#lookup_in_any_replica}
+      #
+      # @param [JsonTranscoder, #decode(String)] transcoder used for encoding
+      #
+      # @param [Integer, #in_milliseconds, nil] timeout
+      # @param [Proc, nil] retry_strategy the custom retry strategy, if set
+      # @param [Hash, nil] client_context the client context data, if set
+      # @param [Span, nil] parent_span if set holds the parent span, that should be used for this request
+      #
+      # @yieldparam [LookupIn] self
+      def initialize(transcoder: JsonTranscoder.new,
+                     timeout: nil,
+                     retry_strategy: nil,
+                     client_context: nil,
+                     parent_span: nil)
+        super(timeout: timeout, retry_strategy: retry_strategy, client_context: client_context, parent_span: parent_span)
+        @transcoder = transcoder
+        yield self if block_given?
+      end
+
+      # @api private
+      def to_backend
+        {
+          timeout: Utils::Time.extract_duration(@timeout),
+        }
+      end
+
+      # @api private
+      # @return [Boolean]
+      attr_accessor :access_deleted
+
+      # @api private
+      DEFAULT = LookupInAnyReplica.new.freeze
+    end
+
+    # Options for {Collection#lookup_in_all_replicas}
+    class LookupInAllReplicas < Base
+      attr_accessor :transcoder # @return [JsonTranscoder, #decode(String)]
+
+      # Creates an instance of options for {Collection#lookup_in_all_replicas}
+      #
+      # @param [JsonTranscoder, #decode(String)] transcoder used for encoding
+      #
+      # @param [Integer, #in_milliseconds, nil] timeout
+      # @param [Proc, nil] retry_strategy the custom retry strategy, if set
+      # @param [Hash, nil] client_context the client context data, if set
+      # @param [Span, nil] parent_span if set holds the parent span, that should be used for this request
+      #
+      # @yieldparam [LookupInAllReplicas] self
+      def initialize(transcoder: JsonTranscoder.new,
+                     timeout: nil,
+                     retry_strategy: nil,
+                     client_context: nil,
+                     parent_span: nil)
+        super(timeout: timeout, retry_strategy: retry_strategy, client_context: client_context, parent_span: parent_span)
+        @transcoder = transcoder
+        yield self if block_given?
+      end
+
+      # @api private
+      def to_backend
+        {
+          timeout: Utils::Time.extract_duration(@timeout),
+        }
+      end
+
+      # @api private
+      DEFAULT = LookupInAllReplicas.new.freeze
+    end
+
     # Options for {Collection#scan}
     class Scan < Base
       attr_accessor :ids_only # @return [Boolean]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -55,6 +55,14 @@ class ServerVersion
     @version >= Gem::Version.create("7.0.0")
   end
 
+  def elixir?
+    @version >= Gem::Version.create("7.5.0")
+  end
+
+  def trinity?
+    @version >= Gem::Version.create("7.6.0")
+  end
+
   def supports_collections?
     cheshire_cat?
   end
@@ -84,7 +92,11 @@ class ServerVersion
   end
 
   def supports_range_scan?
-    @version >= Gem::Version.create("7.5.0")
+    elixir?
+  end
+
+  def supports_subdoc_read_from_replica?
+    elixir?
   end
 end
 


### PR DESCRIPTION
## Changes

* Add support for `Collection#lookup_in_any_replica` and `Collection#lookup_in_all_replicas`
* Changed the wrapper code of `lookup_in` to use the Core API instead of the Public C++ API
* Added relevant options and result classes (`Options::LookupInAnyReplica`, `Options::LookupInAllReplicas`, `Collection::LookupInReplicaResult`)
* Core update

## Results

All tests pass