### PR TITLE
Query/scan test fixes

### DIFF
--- a/test/query_test.rb
+++ b/test/query_test.rb
@@ -224,8 +224,8 @@ module Couchbase
     def test_scoped_query
       skip("The server does not support scoped queries (#{env.server_version})") unless env.server_version.supports_scoped_queries?
 
-      scope_name = uniq_id(:scope).delete(".")[0, 30]
-      collection_name = uniq_id(:collection).delete(".")[0, 30]
+      scope_name = uniq_id(:scope).delete("-")[0, 30]
+      collection_name = uniq_id(:collection).delete("-")[0, 30]
 
       manager = @bucket.collections
       ns_uid = manager.create_scope(scope_name)

--- a/test/scan_test.rb
+++ b/test/scan_test.rb
@@ -321,9 +321,8 @@ module Couchbase
 
     def test_range_scan_collection_does_not_exist
       collection = @bucket.scope("_default").collection(uniq_id(:nonexistent))
-      scan_result = collection.scan(RangeScan.new)
       assert_raises(Error::CollectionNotFound) do
-        validate_scan(scan_result, [])
+        collection.scan(RangeScan.new)
       end
     end
 


### PR DESCRIPTION
* Range scan test fix after core update changed `CollectionNotFound` behaviour
* Query test fix after change in `uniq_id` helper in a previous PR