### PR TITLE
RCBC-451 & RCBC-452: Expose any specific lookup_in spec errors

### DIFF
--- a/ext/couchbase.cxx
+++ b/ext/couchbase.cxx
@@ -3518,8 +3518,10 @@ cb_Backend_document_lookup_in(VALUE self, VALUE bucket, VALUE scope, VALUE colle
                 rb_hash_aset(entry, value_property, cb_str_new(resp_entry.value));
             }
             if (resp_entry.ec && resp_entry.ec != couchbase::errc::key_value::path_not_found) {
-                rb_hash_aset(
-                  entry, error_property, cb_map_error_code(resp_entry.ec, fmt::format("error getting result for spec at index {}, path \"{}\"", i, field_entry.path)));
+                rb_hash_aset(entry,
+                             error_property,
+                             cb_map_error_code(resp_entry.ec,
+                                               fmt::format("error getting result for spec at index {}, path \"{}\"", i, resp_entry.path)));
             }
             rb_ary_store(fields, static_cast<long>(i), entry);
         }
@@ -3627,8 +3629,10 @@ cb_Backend_document_lookup_in_any_replica(VALUE self, VALUE bucket, VALUE scope,
                 rb_hash_aset(entry, value_property, cb_str_new(resp_entry.value));
             }
             if (resp_entry.ec && resp_entry.ec != couchbase::errc::key_value::path_not_found) {
-                rb_hash_aset(
-                  entry, error_property, cb_map_error_code(resp_entry.ec, fmt::format("error getting result for spec at index {}, path \"{}\"", i, field_entry.path)));
+                rb_hash_aset(entry,
+                             error_property,
+                             cb_map_error_code(resp_entry.ec,
+                                               fmt::format("error getting result for spec at index {}, path \"{}\"", i, resp_entry.path)));
             }
             rb_ary_store(fields, static_cast<long>(i), entry);
         }
@@ -3741,9 +3745,11 @@ cb_Backend_document_lookup_in_all_replicas(VALUE self, VALUE bucket, VALUE scope
                     rb_hash_aset(entry, value_property, cb_str_new(field_entry.value));
                 }
                 if (field_entry.ec && field_entry.ec != couchbase::errc::key_value::path_not_found) {
-                    rb_hash_aset(entry,
-                                 error_property,
-                                 cb_map_error_code(field_entry.ec, fmt::format("error getting result for spec at index {}, path \"{}\"", i, field_entry.path)));
+                    rb_hash_aset(
+                      entry,
+                      error_property,
+                      cb_map_error_code(field_entry.ec,
+                                        fmt::format("error getting result for spec at index {}, path \"{}\"", i, field_entry.path)));
                 }
                 rb_ary_store(fields, static_cast<long>(i), entry);
             }

--- a/ext/couchbase.cxx
+++ b/ext/couchbase.cxx
@@ -3501,6 +3501,7 @@ cb_Backend_document_lookup_in(VALUE self, VALUE bucket, VALUE scope, VALUE colle
         static VALUE exists_property = rb_id2sym(rb_intern("exists"));
         static VALUE cas_property = rb_id2sym(rb_intern("cas"));
         static VALUE value_property = rb_id2sym(rb_intern("value"));
+        static VALUE error_property = rb_id2sym(rb_intern("error"));
 
         VALUE res = rb_hash_new();
         rb_hash_aset(res, cas_property, cb_cas_to_num(resp.cas));
@@ -3515,6 +3516,10 @@ cb_Backend_document_lookup_in(VALUE self, VALUE bucket, VALUE scope, VALUE colle
             rb_hash_aset(entry, path_property, cb_str_new(resp_entry.path));
             if (!resp_entry.value.empty()) {
                 rb_hash_aset(entry, value_property, cb_str_new(resp_entry.value));
+            }
+            if (resp_entry.ec && resp_entry.ec != couchbase::errc::key_value::path_not_found) {
+                rb_hash_aset(
+                  entry, error_property, cb_map_error_code(resp_entry.ec, fmt::format("error getting result for spec at index {}", i)));
             }
             rb_ary_store(fields, static_cast<long>(i), entry);
         }
@@ -3602,6 +3607,7 @@ cb_Backend_document_lookup_in_any_replica(VALUE self, VALUE bucket, VALUE scope,
         static VALUE exists_property = rb_id2sym(rb_intern("exists"));
         static VALUE cas_property = rb_id2sym(rb_intern("cas"));
         static VALUE value_property = rb_id2sym(rb_intern("value"));
+        static VALUE error_property = rb_id2sym(rb_intern("error"));
         static VALUE is_replica_property = rb_id2sym(rb_intern("is_replica"));
 
         VALUE res = rb_hash_new();
@@ -3619,6 +3625,10 @@ cb_Backend_document_lookup_in_any_replica(VALUE self, VALUE bucket, VALUE scope,
             rb_hash_aset(entry, path_property, cb_str_new(resp_entry.path));
             if (!resp_entry.value.empty()) {
                 rb_hash_aset(entry, value_property, cb_str_new(resp_entry.value));
+            }
+            if (resp_entry.ec && resp_entry.ec != couchbase::errc::key_value::path_not_found) {
+                rb_hash_aset(
+                  entry, error_property, cb_map_error_code(resp_entry.ec, fmt::format("error getting result for spec at index {}", i)));
             }
             rb_ary_store(fields, static_cast<long>(i), entry);
         }
@@ -3707,6 +3717,7 @@ cb_Backend_document_lookup_in_all_replicas(VALUE self, VALUE bucket, VALUE scope
         static VALUE exists_property = rb_id2sym(rb_intern("exists"));
         static VALUE cas_property = rb_id2sym(rb_intern("cas"));
         static VALUE value_property = rb_id2sym(rb_intern("value"));
+        static VALUE error_property = rb_id2sym(rb_intern("error"));
         static VALUE is_replica_property = rb_id2sym(rb_intern("is_replica"));
 
         auto lookup_in_entries_size = resp.entries.size();
@@ -3728,6 +3739,11 @@ cb_Backend_document_lookup_in_all_replicas(VALUE self, VALUE bucket, VALUE scope
                 rb_hash_aset(entry, path_property, cb_str_new(field_entry.path));
                 if (!field_entry.value.empty()) {
                     rb_hash_aset(entry, value_property, cb_str_new(field_entry.value));
+                }
+                if (field_entry.ec && field_entry.ec != couchbase::errc::key_value::path_not_found) {
+                    rb_hash_aset(entry,
+                                 error_property,
+                                 cb_map_error_code(field_entry.ec, fmt::format("error getting result for spec at index {}", i)));
                 }
                 rb_ary_store(fields, static_cast<long>(i), entry);
             }

--- a/ext/couchbase.cxx
+++ b/ext/couchbase.cxx
@@ -3519,7 +3519,7 @@ cb_Backend_document_lookup_in(VALUE self, VALUE bucket, VALUE scope, VALUE colle
             }
             if (resp_entry.ec && resp_entry.ec != couchbase::errc::key_value::path_not_found) {
                 rb_hash_aset(
-                  entry, error_property, cb_map_error_code(resp_entry.ec, fmt::format("error getting result for spec at index {}", i)));
+                  entry, error_property, cb_map_error_code(resp_entry.ec, fmt::format("error getting result for spec at index {}, path \"{}\"", i, field_entry.path)));
             }
             rb_ary_store(fields, static_cast<long>(i), entry);
         }
@@ -3628,7 +3628,7 @@ cb_Backend_document_lookup_in_any_replica(VALUE self, VALUE bucket, VALUE scope,
             }
             if (resp_entry.ec && resp_entry.ec != couchbase::errc::key_value::path_not_found) {
                 rb_hash_aset(
-                  entry, error_property, cb_map_error_code(resp_entry.ec, fmt::format("error getting result for spec at index {}", i)));
+                  entry, error_property, cb_map_error_code(resp_entry.ec, fmt::format("error getting result for spec at index {}, path \"{}\"", i, field_entry.path)));
             }
             rb_ary_store(fields, static_cast<long>(i), entry);
         }
@@ -3743,7 +3743,7 @@ cb_Backend_document_lookup_in_all_replicas(VALUE self, VALUE bucket, VALUE scope
                 if (field_entry.ec && field_entry.ec != couchbase::errc::key_value::path_not_found) {
                     rb_hash_aset(entry,
                                  error_property,
-                                 cb_map_error_code(field_entry.ec, fmt::format("error getting result for spec at index {}", i)));
+                                 cb_map_error_code(field_entry.ec, fmt::format("error getting result for spec at index {}, path \"{}\"", i, field_entry.path)));
                 }
                 rb_ary_store(fields, static_cast<long>(i), entry);
             }

--- a/lib/couchbase/collection.rb
+++ b/lib/couchbase/collection.rb
@@ -482,6 +482,7 @@ module Couchbase
             f.index = field[:index]
             f.path = field[:path]
             f.value = field[:value]
+            f.error = field[:error]
           end
         end
       end
@@ -649,6 +650,7 @@ module Couchbase
             f.index = field[:index]
             f.path = field[:path]
             f.value = field[:value]
+            f.error = field[:error]
           end
         end
       end

--- a/lib/couchbase/collection_options.rb
+++ b/lib/couchbase/collection_options.rb
@@ -310,7 +310,7 @@ module Couchbase
       # @return [String] path
       attr_accessor :path
 
-      # @return [CouchbaseError] path
+      # @return [CouchbaseError] error
       attr_accessor :error
 
       # @yieldparam [SubDocumentField] self

--- a/lib/couchbase/collection_options.rb
+++ b/lib/couchbase/collection_options.rb
@@ -167,6 +167,8 @@ module Couchbase
       # @return [Object] the decoded
       def content(path_or_index, transcoder = self.transcoder)
         field = get_field_at_index(path_or_index)
+
+        raise field.error unless field.error.nil?
         raise Error::PathNotFound, "Path is not found: #{path_or_index}" unless field.exists
 
         transcoder.decode(field.value, :json)
@@ -188,6 +190,8 @@ module Couchbase
             encoded[path_or_index]
           end
         return false unless field
+
+        raise field.error unless field.error.nil?
 
         field.exists
       end
@@ -305,6 +309,9 @@ module Couchbase
 
       # @return [String] path
       attr_accessor :path
+
+      # @return [CouchbaseError] path
+      attr_accessor :error
 
       # @yieldparam [SubDocumentField] self
       def initialize

--- a/test/subdoc_test.rb
+++ b/test/subdoc_test.rb
@@ -1448,5 +1448,123 @@ module Couchbase
                                            ])
       end
     end
+
+    def test_lookup_in_path_invalid
+      doc_id = uniq_id(:foo)
+      document = {"value" => 42}
+      @collection.upsert(doc_id, document)
+
+      res = @collection.lookup_in(doc_id, [
+                                    LookupInSpec.get("value.."),
+                                  ])
+
+      assert_raises(Error::PathInvalid) do
+        res.exists?(0)
+      end
+      assert_raises(Error::PathInvalid) do
+        res.content(0)
+      end
+    end
+
+    def test_lookup_in_path_mismatch
+      doc_id = uniq_id(:foo)
+      document = {"value" => 42}
+      @collection.upsert(doc_id, document)
+
+      res = @collection.lookup_in(doc_id, [
+                                    LookupInSpec.count("value"),
+                                  ])
+
+      assert_raises(Error::PathMismatch) do
+        res.exists?(0)
+      end
+      assert_raises(Error::PathMismatch) do
+        res.content(0)
+      end
+    end
+
+    def test_lookup_in_any_replica_path_invalid
+      skip("#{name}: CAVES does not support subdoc read from replica yet") if use_caves?
+      skip("#{name}: Server does not support subdoc read from replica") unless env.server_version.supports_subdoc_read_from_replica?
+
+      doc_id = uniq_id(:foo)
+      document = {"value" => 42}
+      @collection.upsert(doc_id, document, Options::Upsert.new(durability_level: :majority_and_persist_to_active))
+
+      res = @collection.lookup_in_any_replica(doc_id, [
+                                                LookupInSpec.count("value.."),
+                                              ])
+
+      assert_raises(Error::PathInvalid) do
+        res.exists?(0)
+      end
+      assert_raises(Error::PathInvalid) do
+        res.content(0)
+      end
+    end
+
+    def test_lookup_in_any_replica_path_mismatch
+      skip("#{name}: CAVES does not support subdoc read from replica yet") if use_caves?
+      skip("#{name}: Server does not support subdoc read from replica") unless env.server_version.supports_subdoc_read_from_replica?
+
+      doc_id = uniq_id(:foo)
+      document = {"value" => 42}
+      @collection.upsert(doc_id, document, Options::Upsert.new(durability_level: :majority_and_persist_to_active))
+
+      res = @collection.lookup_in_any_replica(doc_id, [
+                                                LookupInSpec.count("value"),
+                                              ])
+
+      assert_raises(Error::PathMismatch) do
+        res.exists?(0)
+      end
+      assert_raises(Error::PathMismatch) do
+        res.content(0)
+      end
+    end
+
+    def test_lookup_in_all_replicas_path_invalid
+      skip("#{name}: CAVES does not support subdoc read from replica yet") if use_caves?
+      skip("#{name}: Server does not support subdoc read from replica") unless env.server_version.supports_subdoc_read_from_replica?
+
+      doc_id = uniq_id(:foo)
+      document = {"value" => 42}
+      @collection.upsert(doc_id, document, Options::Upsert.new(durability_level: :majority_and_persist_to_active))
+
+      res = @collection.lookup_in_all_replicas(doc_id, [
+                                                 LookupInSpec.count("value.."),
+                                               ])
+
+      res.each do |entry|
+        assert_raises(Error::PathInvalid) do
+          entry.exists?(0)
+        end
+        assert_raises(Error::PathInvalid) do
+          entry.content(0)
+        end
+      end
+    end
+
+    def test_lookup_in_all_replicas_path_mismatch
+      skip("#{name}: CAVES does not support subdoc read from replica yet") if use_caves?
+      skip("#{name}: Server does not support subdoc read from replica") unless env.server_version.supports_subdoc_read_from_replica?
+
+      doc_id = uniq_id(:foo)
+      document = {"value" => 42}
+      @collection.upsert(doc_id, document, Options::Upsert.new(durability_level: :majority_and_persist_to_active))
+
+      res = @collection.lookup_in_all_replicas(doc_id, [
+                                                 LookupInSpec.count("value"),
+                                               ])
+
+      res.each do |entry|
+        assert_raises(Error::PathMismatch) do
+          entry.exists?(0)
+        end
+        assert_raises(Error::PathMismatch) do
+          entry.content(0)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Motivation
Any spec-specific errors were ignored which resulted in any error that happens being exposed `PathNotFound` (because of the absence of content)

## Changes
Add an `error` attribute to the `SubDocumentField` class that stores the Ruby error that is equivalent to the spec-specific error code from the C++ response. This error is raised then `content` or `exists?` for that spec are called