### PR TITLE
RCBC-453: Support history retention in collection and bucket management

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.0
       - name: Install dependencies
         run: bundle install
       - name: Run rubocop
@@ -43,7 +43,7 @@ jobs:
       - name: Set up ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.0
       - name: Install dependencies
         run: |
           sudo apt-get update -y

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ require:
   - rubocop-thread_safety
 
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
   NewCops: enable
   SuggestExtensions: false
   Exclude:

--- a/lib/couchbase/management/bucket_manager.rb
+++ b/lib/couchbase/management/bucket_manager.rb
@@ -211,12 +211,15 @@ module Couchbase
             num_replicas: settings.num_replicas,
             replica_indexes: settings.replica_indexes,
             bucket_type: settings.bucket_type,
-            ejection_policy: settings.ejection_policy,
+            eviction_policy: settings.eviction_policy,
             max_expiry: settings.max_expiry,
             compression_mode: settings.compression_mode,
             minimum_durability_level: settings.minimum_durability_level,
             conflict_resolution_type: settings.conflict_resolution_type,
             storage_backend: settings.storage_backend,
+            history_retention_collection_default: settings.history_retention_collection_default,
+            history_retention_duration: settings.history_retention_duration,
+            history_retention_bytes: settings.history_retention_bytes,
           }, options.to_backend
         )
       end
@@ -239,11 +242,14 @@ module Couchbase
             num_replicas: settings.num_replicas,
             replica_indexes: settings.replica_indexes,
             bucket_type: settings.bucket_type,
-            ejection_policy: settings.ejection_policy,
+            eviction_policy: settings.eviction_policy,
             max_expiry: settings.max_expiry,
             compression_mode: settings.compression_mode,
             minimum_durability_level: settings.minimum_durability_level,
             storage_backend: settings.storage_backend,
+            history_retention_collection_default: settings.history_retention_collection_default,
+            history_retention_bytes: settings.history_retention_bytes,
+            history_retention_duration: settings.history_retention_duration,
           }, options.to_backend
         )
       end
@@ -334,6 +340,9 @@ module Couchbase
           bucket.minimum_durability_level = entry[:minimum_durability_level]
           bucket.compression_mode = entry[:compression_mode]
           bucket.instance_variable_set(:@healthy, entry[:nodes].all? { |node| node[:status] == "healthy" })
+          bucket.history_retention_collection_default = entry[:history_retention_collection_default]
+          bucket.history_retention_bytes = entry[:history_retention_bytes]
+          bucket.history_retention_duration = entry[:history_retention_duration]
         end
       end
     end
@@ -394,6 +403,17 @@ module Couchbase
       # @return [nil, :none, :majority, :majority_and_persist_to_active, :persist_to_majority] the minimum durability level
       attr_accessor :minimum_durability_level
 
+      # @return [Boolean, nil] whether to enable history retention on collections  by default
+      attr_accessor :history_retention_collection_default
+
+      # @return [Integer, nil] the maximum size, in bytes, of the change history that is written to disk for all
+      # collections in this bucket
+      attr_accessor :history_retention_bytes
+
+      # @return [Integer, nil] the maximum duration, in seconds, to be covered by the change history that is written to disk for all
+      # collections in this bucket
+      attr_accessor :history_retention_duration
+
       # @api private
       # @return [Boolean] false if status of the bucket is not healthy
       def healthy?
@@ -429,6 +449,9 @@ module Couchbase
         @conflict_resolution_type = :sequence_number
         @eviction_policy = :value_only
         @storage_backend = nil
+        @history_retention_collection_default = nil
+        @history_retention_bytes = nil
+        @history_retention_duration = nil
         yield self if block_given?
       end
     end

--- a/lib/couchbase/management/collection_manager.rb
+++ b/lib/couchbase/management/collection_manager.rb
@@ -38,6 +38,8 @@ module Couchbase
             super
             yield self if block_given?
           end
+
+          DEFAULT = GetAllScopes.new.freeze
         end
 
         # Options for {CollectionManager#create_scope}
@@ -57,6 +59,8 @@ module Couchbase
             super
             yield self if block_given?
           end
+
+          DEFAULT = CreateScope.new.freeze
         end
 
         # Options for {CollectionManager#drop_scope}
@@ -76,6 +80,8 @@ module Couchbase
             super
             yield self if block_given?
           end
+
+          DEFAULT = DropScope.new.freeze
         end
 
         # Options for {CollectionManager#create_collection}
@@ -95,6 +101,29 @@ module Couchbase
             super
             yield self if block_given?
           end
+
+          DEFAULT = CreateCollection.new.freeze
+        end
+
+        # Options for {CollectionManager#update_collection}
+        class UpdateCollection < ::Couchbase::Options::Base
+          # Creates an instance of options for {CollectionManager#update_collection}
+          #
+          # @param [Integer, #in_milliseconds, nil] timeout the time in milliseconds allowed for the operation to complete
+          # @param [Proc, nil] retry_strategy the custom retry strategy, if set
+          # @param [Hash, nil] client_context the client context data, if set
+          # @param [Span, nil] parent_span if set holds the parent span, that should be used for this request
+          #
+          # @yieldparam [UpdateCollection] self
+          def initialize(timeout: nil,
+                         retry_strategy: nil,
+                         client_context: nil,
+                         parent_span: nil)
+            super
+            yield self if block_given?
+          end
+
+          DEFAULT = UpdateCollection.new.freeze
         end
 
         # Options for {CollectionManager#drop_collection}
@@ -114,6 +143,8 @@ module Couchbase
             super
             yield self if block_given?
           end
+
+          DEFAULT = DropCollection.new.freeze
         end
 
         # rubocop:disable Naming/MethodName constructor shortcuts
@@ -184,6 +215,8 @@ module Couchbase
               CollectionSpec.new do |collection|
                 collection.name = c[:name]
                 collection.scope_name = s[:name]
+                collection.max_expiry = c[:max_expiry]
+                collection.history = c[:history]
               end
             end
           end
@@ -232,29 +265,88 @@ module Couchbase
       end
 
       # Creates a new collection
+      # @overload create_collection(scope_name, collection_name, settings = CreateCollectionSettings::DEFAULT,
+      #  options = Options::Collection::CreateCollection::DEFAULT)
+      #   @param [String] scope_name the name of the scope the collection will be created in
+      #   @param [String] collection_name the name of the collection to be created
+      #   @param [CreateCollectionSettings] settings settings for the new collection
+      #   @param [Options::Collection::CreateCollection] options
       #
-      # @param [CollectionSpec] collection specification of the collection
-      # @param [Options::Collection::CreateCollection] options
+      # @overload create_collection(collection, options = Options::Collection::CreateCollection)
+      #   @param [CollectionSpec] collection specification of the collection
+      #   @param [Options::Collection::CreateCollection] options
+      #
+      #   @deprecated Use +#create_collection(scope_name, collection_name, settings, options)+ instead
       #
       # @return void
       #
       # @raise [ArgumentError]
-      # @raise [Error::CollectionExist]
+      # @raise [Error::CollectionExists]
       # @raise [Error::ScopeNotFound]
-      def create_collection(collection, options = Options::Collection::CreateCollection.new)
-        @backend.collection_create(@bucket_name, collection.scope_name, collection.name, collection.max_expiry, options.to_backend)
+      def create_collection(*args)
+        if args[0].is_a?(CollectionSpec)
+          collection = args[0]
+          options = args[1] || Options::Collection::CreateCollection::DEFAULT
+          settings = CreateCollectionSettings.new(max_expiry: collection.max_expiry, history: collection.history)
+
+          warn "Calling create_collection with a CollectionSpec object has been deprecated, supply scope name, " \
+               "collection name and optionally a CreateCollectionSettings instance"
+
+          @backend.collection_create(@bucket_name, collection.scope_name, collection.name, settings.to_backend, options.to_backend)
+        else
+          scope_name = args[0]
+          collection_name = args[1]
+          settings = args[2] || CreateCollectionSettings::DEFAULT
+          options = args[3] || Options::Collection::CreateCollection::DEFAULT
+          @backend.collection_create(@bucket_name, scope_name, collection_name, settings.to_backend, options.to_backend)
+        end
+      end
+
+      # Updates the settings of an existing collection
+      #
+      # @param [String] scope_name the name of the scope the collection is in
+      # @param [String] collection_name the name of the collection to be updated
+      # @param [UpdateCollectionSettings] settings the settings that should be updated
+      #
+      # @raise [ArgumentError]
+      # @raise [Error::CollectionNotFound]
+      # @raise [Error::ScopeNotFound]
+      def update_collection(scope_name, collection_name, settings = UpdateCollectionSettings::DEFAULT,
+                            options = Options::Collection::UpdateCollection::DEFAULT)
+        @backend.collection_update(@bucket_name, scope_name, collection_name, settings.to_backend, options.to_backend)
       end
 
       # Removes a collection
+      # @overload drop_collection(scope_name, collection_name, settings = CreateCollectionSettings::DEFAULT,
+      #   options = Options::Collection::CreateCollection::DEFAULT)
+      #   @param [String] scope_name the name of the scope the collection is in
+      #   @param [String] collection_name the name of the collection to be removed
       #
-      # @param [CollectionSpec] collection specification of the collection
-      # @param [Options::Collection::DropCollection] options
+      # @overload drop_collection(collection, options = Options::Collection::CreateCollection)
+      #   @param [CollectionSpec] collection specification of the collection
+      #   @param [Options::Collection::CreateCollection] options
+      #
+      #   @deprecated Use +#drop_collection(scope_name, collection_name, options)+ instead
       #
       # @return void
       #
+      # @raise [ArgumentError]
       # @raise [Error::CollectionNotFound]
-      def drop_collection(collection, options = Options::Collection::DropCollection.new)
-        @backend.collection_drop(@bucket_name, collection.scope_name, collection.name, options.to_backend)
+      # @raise [Error::ScopeNotFound]
+      def drop_collection(*args)
+        if args[0].is_a?(CollectionSpec)
+          collection = args[0]
+          options = args[1] || Options::Collection::CreateCollection::DEFAULT
+
+          warn "Calling drop_collection with a CollectionSpec object has been deprecated, supply scope name and collection name"
+
+          @backend.collection_drop(@bucket_name, collection.scope_name, collection.name, options.to_backend)
+        else
+          scope_name = args[0]
+          collection_name = args[1]
+          options = args[2] || Options::Collection::CreateCollection::DEFAULT
+          @backend.collection_drop(@bucket_name, scope_name, collection_name, options.to_backend)
+        end
       end
 
       # @deprecated use {CollectionManager#get_all_scopes} instead
@@ -289,6 +381,60 @@ module Couchbase
       DropCollectionOptions = ::Couchbase::Management::Options::Collection::DropCollection
     end
 
+    class CreateCollectionSettings
+      # @return [Integer, nil] time in seconds of the maximum expiration time for new documents in the collection
+      # (set to +nil+ to disable it)
+      attr_accessor :max_expiry
+
+      # @return [Boolean, nil] whether history retention override should be enabled in the collection (set to +nil+ to
+      # default to the bucket-level setting)
+      attr_accessor :history
+
+      def initialize(max_expiry: nil, history: nil)
+        @max_expiry = max_expiry
+        @history = history
+
+        yield self if block_given?
+      end
+
+      # @api private
+      def to_backend
+        {
+          max_expiry: @max_expiry,
+          history: @history,
+        }
+      end
+
+      DEFAULT = CreateCollectionSettings.new.freeze
+    end
+
+    class UpdateCollectionSettings
+      # @return [Integer, nil] time in seconds of the maximum expiration time for new documents in the collection
+      # (set to +nil+ to disable it)
+      attr_accessor :max_expiry
+
+      # @return [Boolean, nil] whether history retention override should be enabled in the collection (set to +nil+ to
+      # default to the bucket-level setting)
+      attr_accessor :history
+
+      def initialize(max_expiry: nil, history: nil)
+        @max_expiry = max_expiry
+        @history = history
+
+        yield self if block_given?
+      end
+
+      # @api private
+      def to_backend
+        {
+          max_expiry: @max_expiry,
+          history: @history,
+        }
+      end
+
+      DEFAULT = UpdateCollectionSettings.new.freeze
+    end
+
     class ScopeSpec
       # @return [String] name of the scope
       attr_accessor :name
@@ -311,6 +457,9 @@ module Couchbase
 
       # @return [Integer] time in seconds of the expiration for new documents in the collection (set to +nil+ to disable it)
       attr_accessor :max_expiry
+
+      # @return [Boolean, nil] whether history retention is enabled for this collection
+      attr_accessor :history
 
       # @yieldparam [CollectionSpec] self
       def initialize

--- a/test/bucket_manager_test.rb
+++ b/test/bucket_manager_test.rb
@@ -1,0 +1,143 @@
+#  Copyright 2023. Couchbase, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+require_relative "test_helper"
+
+module Couchbase
+  class BucketManagerTest < Minitest::Test
+    include TestUtilities
+
+    def get_bucket_name
+      name = uniq_id(:bucket_mgr_test)
+      @used_buckets << name
+      name
+    end
+
+    def setup
+      connect
+      @used_buckets = []
+      @bucket_manager = @cluster.buckets
+    end
+
+    def teardown
+      @used_buckets.each do |bucket_name|
+        @bucket_manager.drop_bucket(bucket_name)
+      rescue Error::BucketNotFound
+        # Ignored
+      end
+      disconnect
+    end
+
+    def test_create_bucket_history_retention
+      skip("#{name}: Server does not support history retention") unless env.server_version.supports_history_retention?
+
+      bucket_name = get_bucket_name
+      @bucket_manager.create_bucket(
+        Couchbase::Management::BucketSettings.new do |s|
+          s.name = bucket_name
+          s.storage_backend = :magma
+          s.ram_quota_mb = 1024
+          s.history_retention_collection_default = false
+          s.history_retention_bytes = 2147483648
+          s.history_retention_duration = 600
+        end
+      )
+      res = @bucket_manager.get_bucket(bucket_name)
+
+      refute res.history_retention_collection_default
+      assert_equal 2**31, res.history_retention_bytes
+      assert_equal 600, res.history_retention_duration
+    end
+
+    def test_create_bucket_history_retention_unsupported
+      skip("#{name}: Server does not support history retention") unless env.server_version.supports_history_retention?
+
+      bucket_name = get_bucket_name
+      assert_raises(Error::InvalidArgument) do
+        @bucket_manager.create_bucket(
+          Couchbase::Management::BucketSettings.new do |s|
+            s.name = bucket_name
+            s.storage_backend = :couchstore
+            s.history_retention_collection_default = false
+            s.history_retention_bytes = 2**31
+            s.history_retention_duration = 600
+          end
+        )
+      end
+    end
+
+    def test_update_bucket_history_retention
+      skip("#{name}: Server does not support history retention") unless env.server_version.supports_history_retention?
+
+      bucket_name = get_bucket_name
+      @bucket_manager.create_bucket(
+        Couchbase::Management::BucketSettings.new do |s|
+          s.name = bucket_name
+          s.storage_backend = :magma
+          s.ram_quota_mb = 1024
+        end
+      )
+      res = @bucket_manager.get_bucket(bucket_name)
+
+      assert res.history_retention_collection_default
+      assert_equal 0, res.history_retention_bytes
+      assert_equal 0, res.history_retention_duration
+
+      @bucket_manager.update_bucket(
+        Couchbase::Management::BucketSettings.new do |s|
+          s.name = bucket_name
+          s.storage_backend = :magma
+          s.ram_quota_mb = 1024
+          s.history_retention_collection_default = false
+          s.history_retention_bytes = 2147483648
+          s.history_retention_duration = 600
+        end
+      )
+      res = @bucket_manager.get_bucket(bucket_name)
+
+      refute res.history_retention_collection_default
+      assert_equal 2**31, res.history_retention_bytes
+      assert_equal 600, res.history_retention_duration
+    end
+
+    def test_update_bucket_history_retention_unsupported
+      skip("#{name}: Server does not support history retention") unless env.server_version.supports_history_retention?
+
+      bucket_name = get_bucket_name
+      @bucket_manager.create_bucket(
+        Couchbase::Management::BucketSettings.new do |s|
+          s.name = bucket_name
+          s.storage_backend = :couchstore
+        end
+      )
+      res = @bucket_manager.get_bucket(bucket_name)
+
+      assert_nil res.history_retention_collection_default
+      assert_equal 0, res.history_retention_bytes
+      assert_equal 0, res.history_retention_duration
+
+      assert_raises(Error::InvalidArgument) do
+        @bucket_manager.update_bucket(
+          Couchbase::Management::BucketSettings.new do |s|
+            s.name = bucket_name
+            s.storage_backend = :couchstore
+            s.history_retention_collection_default = false
+            s.history_retention_bytes = 2147483648
+            s.history_retention_duration = 600
+          end
+        )
+      end
+    end
+  end
+end

--- a/test/collection_manager_test.rb
+++ b/test/collection_manager_test.rb
@@ -1,0 +1,438 @@
+#  Copyright 2023. Couchbase, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+require "test_helper"
+
+module Couchbase
+  class CollectionManagerTest < Minitest::Test
+    include TestUtilities
+
+    TEST_MAGMA_BUCKET_NAME = 'test-magma-bucket'.freeze
+
+    def create_magma_bucket
+      @cluster.buckets.create_bucket(
+        Management::BucketSettings.new do |s|
+          s.name = TEST_MAGMA_BUCKET_NAME
+          s.storage_backend = :magma
+          s.ram_quota_mb = 1024
+        end
+      )
+      begin
+      end
+      retry_for_duration(expected_errors: [Error::BucketNotFound]) do
+        @magma_bucket = @cluster.bucket(TEST_MAGMA_BUCKET_NAME)
+      end
+      @magma_collection_manager = @magma_bucket.collections
+    end
+
+    def get_scope_name
+      name = uniq_id(:coll_mgr_test)
+      @used_scopes << name
+      name
+    end
+
+    def get_scope(scope_name, mgr = nil)
+      mgr ||= @collection_manager
+      mgr.get_all_scopes.find { |scope| scope.name == scope_name }
+    end
+
+    def get_collection(scope_name, collection_name, mgr = nil)
+      mgr ||= @collection_manager
+      mgr.get_all_scopes
+         .find { |scope| scope.name == scope_name }
+         .collections
+         .find { |collection| collection.name == collection_name }
+    end
+
+    def setup
+      connect
+      @used_scopes = []
+      @bucket = @cluster.bucket(env.bucket)
+      @collection_manager = @bucket.collections
+    end
+
+    def teardown
+      @used_scopes.each do |scope_name|
+        @collection_manager.drop_scope(scope_name)
+      rescue Error::ScopeNotFound
+        # Ignored
+      end
+      @used_scopes = []
+
+      unless @magma_bucket.nil?
+        begin
+          @cluster.buckets.drop_bucket(TEST_MAGMA_BUCKET_NAME)
+        rescue Error::BucketNotFound
+          # Ignored
+        end
+      end
+      @magma_bucket = nil
+      @magma_collection_manager = nil
+      disconnect
+    end
+
+    def test_create_scope
+      scope_name = get_scope_name
+      @collection_manager.create_scope(scope_name)
+      scope = get_scope(scope_name)
+
+      refute_nil scope
+    end
+
+    def test_drop_scope
+      scope_name = get_scope_name
+      @collection_manager.create_scope(scope_name)
+      scope = get_scope(scope_name)
+
+      refute_nil scope
+
+      @collection_manager.drop_scope(scope_name)
+      scope = get_scope(scope_name)
+
+      assert_nil scope
+    end
+
+    def test_create_collection
+      coll_names = %w[coll-1 coll-2 coll-3]
+      scope_name = get_scope_name
+      @collection_manager.create_scope(scope_name)
+      coll_names.each do |coll_name|
+        @collection_manager.create_collection(scope_name, coll_name)
+      end
+      scope = get_scope(scope_name)
+
+      refute_nil scope
+      assert_equal coll_names.sort, scope.collections.map(&:name).sort
+    end
+
+    def test_drop_collection
+      coll_names = %w[coll-1 coll-2 coll-3]
+      scope_name = get_scope_name
+      @collection_manager.create_scope(scope_name)
+      coll_names.each do |coll_name|
+        @collection_manager.create_collection(scope_name, coll_name)
+      end
+      scope = get_scope(scope_name)
+
+      refute_nil scope
+      assert_equal coll_names.sort, scope.collections.map(&:name).sort
+
+      @collection_manager.drop_collection(scope_name, 'coll-1')
+      scope = get_scope(scope_name)
+
+      refute_includes scope.collections.map(&:name), 'coll-1'
+    end
+
+    def test_create_collection_already_exists
+      coll_name = 'coll-1'
+      scope_name = get_scope_name
+      @collection_manager.create_scope(scope_name)
+      @collection_manager.create_collection(scope_name, coll_name)
+
+      refute_nil get_collection(scope_name, coll_name)
+
+      assert_raises(Error::CollectionExists) do
+        @collection_manager.create_collection(scope_name, coll_name)
+      end
+    end
+
+    def test_create_collection_scope_does_not_exist
+      coll_name = 'coll-1'
+      scope_name = 'does-not-exist'
+
+      assert_raises(Error::ScopeNotFound) do
+        @collection_manager.create_collection(scope_name, coll_name)
+      end
+    end
+
+    def test_create_scope_already_exists
+      scope_name = get_scope_name
+      @collection_manager.create_scope(scope_name)
+
+      refute_nil get_scope(scope_name)
+
+      assert_raises(Error::ScopeExists) do
+        @collection_manager.create_scope(scope_name)
+      end
+    end
+
+    def test_drop_scope_does_not_exist
+      scope_name = 'does-not-exist'
+
+      assert_raises(Error::ScopeNotFound) do
+        @collection_manager.drop_scope(scope_name)
+      end
+    end
+
+    def test_drop_collection_does_not_exist
+      scope_name = get_scope_name
+      coll_name = 'does-not-exist'
+      @collection_manager.create_scope(scope_name)
+
+      refute_nil get_scope(scope_name)
+
+      assert_raises(Error::CollectionNotFound) do
+        @collection_manager.drop_collection(scope_name, coll_name)
+      end
+    end
+
+    def test_drop_collection_scope_does_not_exist
+      scope_name = 'does-not-exist'
+      coll_name = 'does-not-exist'
+
+      assert_raises(Error::ScopeNotFound) do
+        @collection_manager.drop_collection(scope_name, coll_name)
+      end
+    end
+
+    def test_create_collection_history_retention
+      skip("#{name}: Server does not support history retention") unless env.server_version.supports_history_retention?
+
+      create_magma_bucket
+      scope_name = get_scope_name
+      collection_name = 'test-coll'
+      @magma_collection_manager.create_scope(scope_name)
+      scope = get_scope(scope_name, @magma_collection_manager)
+
+      assert scope
+
+      settings = Management::CreateCollectionSettings.new(history: true)
+      @magma_collection_manager.create_collection(scope_name, collection_name, settings)
+
+      coll = get_collection(scope_name, collection_name, @magma_collection_manager)
+
+      assert coll
+      assert coll.history
+    end
+
+    def test_update_collection_history_retention
+      skip("#{name}: Server does not support history retention") unless env.server_version.supports_history_retention?
+      skip("#{name}: Server does not support update_collection") unless env.server_version.supports_update_collection?
+
+      create_magma_bucket
+      scope_name = get_scope_name
+      collection_name = 'test-coll'
+      @magma_collection_manager.create_scope(scope_name)
+      scope = get_scope(scope_name, @magma_collection_manager)
+
+      assert scope
+
+      settings = Management::CreateCollectionSettings.new(history: false)
+      @magma_collection_manager.create_collection(scope_name, collection_name, settings)
+
+      coll = get_collection(scope_name, collection_name, @magma_collection_manager)
+
+      assert coll
+      refute coll.history
+
+      settings = Management::UpdateCollectionSettings.new(history: true)
+      @magma_collection_manager.update_collection(scope_name, collection_name, settings)
+
+      coll = get_collection(scope_name, collection_name, @magma_collection_manager)
+
+      assert coll
+      assert coll.history
+    end
+
+    def test_create_collection_history_retention_unsupported
+      skip("#{name}: Server does not support history retention") unless env.server_version.supports_history_retention?
+
+      scope_name = get_scope_name
+      collection_name = 'test-coll'
+      @collection_manager.create_scope(scope_name)
+      scope = get_scope(scope_name)
+
+      assert scope
+
+      settings = Management::CreateCollectionSettings.new(history: true)
+      assert_raises(Error::FeatureNotAvailable) do
+        @collection_manager.create_collection(scope_name, collection_name, settings)
+      end
+    end
+
+    def test_update_collection_history_retention_unsupported
+      skip("#{name}: Server does not support history retention") unless env.server_version.supports_history_retention?
+      skip("#{name}: Server does not support update_collection") unless env.server_version.supports_update_collection?
+
+      scope_name = get_scope_name
+      collection_name = 'test-coll'
+      @collection_manager.create_scope(scope_name)
+      scope = get_scope(scope_name)
+
+      assert scope
+
+      @collection_manager.create_collection(scope_name, collection_name)
+
+      coll = get_collection(scope_name, collection_name)
+
+      assert coll
+      refute coll.history
+
+      settings = Management::UpdateCollectionSettings.new(history: true)
+
+      assert_raises(Error::FeatureNotAvailable) do
+        @collection_manager.update_collection(scope_name, collection_name, settings)
+      end
+    end
+
+    def test_create_collection_max_expiry
+      scope_name = get_scope_name
+      collection_name = 'test-coll'
+      @collection_manager.create_scope(scope_name)
+      scope = get_scope(scope_name)
+
+      assert scope
+
+      settings = Management::CreateCollectionSettings.new(max_expiry: 1)
+      @collection_manager.create_collection(scope_name, collection_name, settings)
+
+      coll_spec = get_collection(scope_name, collection_name)
+
+      assert coll_spec
+      assert_equal 1, coll_spec.max_expiry
+
+      # Upsert a document and verify that it cannot be found after 1 second
+      key = 'test-doc'
+      content = {'foo' => 'bar'}
+      coll = @bucket.scope(scope_name).collection(collection_name)
+      retry_for_duration(expected_errors: [Error::CollectionNotFound, Error::ScopeNotFound], duration: 10) do
+        coll.upsert(key, content)
+      end
+
+      assert_equal content, coll.get(key).content
+
+      sleep(1)
+
+      retry_until_error(error: Error::DocumentNotFound) do
+        coll.get(key)
+      end
+    end
+
+    def test_update_collection_max_expiry
+      unless env.server_version.supports_update_collection_max_expiry?
+        skip("#{name}: Server does not support update_collection with max_expiry")
+      end
+
+      scope_name = get_scope_name
+      collection_name = 'test-coll'
+      @collection_manager.create_scope(scope_name)
+      scope = get_scope(scope_name)
+
+      assert scope
+
+      settings = Management::CreateCollectionSettings.new(max_expiry: 600)
+      @collection_manager.create_collection(scope_name, collection_name, settings)
+
+      coll_spec = get_collection(scope_name, collection_name)
+
+      assert coll_spec
+      assert_equal 600, coll_spec.max_expiry
+
+      settings = Management::UpdateCollectionSettings.new(max_expiry: 1)
+      @collection_manager.update_collection(scope_name, collection_name, settings)
+
+      coll_spec = get_collection(scope_name, collection_name)
+
+      assert coll_spec
+      assert_equal 1, coll_spec.max_expiry
+
+      # Upsert a document and verify that it cannot be found after 1 second
+      key = 'test-doc'
+      content = {'foo' => 'bar'}
+      coll = @bucket.scope(scope_name).collection(collection_name)
+      retry_for_duration(expected_errors: [Error::CollectionNotFound, Error::ScopeNotFound, Error::Timeout], duration: 10) do
+        coll.upsert(key, content)
+      end
+
+      assert_equal content, coll.get(key).content
+
+      sleep(1)
+
+      retry_until_error(error: Error::DocumentNotFound) do
+        coll.get(key)
+      end
+    end
+
+    def test_update_collection_does_not_exist
+      unless env.server_version.supports_update_collection_max_expiry?
+        skip("#{name}: Server does not support update_collection with max_expiry")
+      end
+
+      scope_name = get_scope_name
+      coll_name = 'does-not-exist'
+      @collection_manager.create_scope(scope_name)
+
+      refute_nil get_scope(scope_name)
+
+      settings = Management::UpdateCollectionSettings.new(max_expiry: 10)
+
+      assert_raises(Error::CollectionNotFound) do
+        @collection_manager.update_collection(scope_name, coll_name, settings)
+      end
+    end
+
+    def test_update_collection_scope_does_not_exist
+      unless env.server_version.supports_update_collection_max_expiry?
+        skip("#{name}: Server does not support update_collection with max_expiry")
+      end
+
+      scope_name = 'does-not-exist'
+      coll_name = 'does-not-exist'
+      settings = Management::UpdateCollectionSettings.new(max_expiry: 10)
+
+      assert_raises(Error::ScopeNotFound) do
+        @collection_manager.update_collection(scope_name, coll_name, settings)
+      end
+    end
+
+    def test_create_collection_deprecated
+      scope_name = get_scope_name
+      coll_name = 'coll-1'
+      @collection_manager.create_scope(scope_name)
+      @collection_manager.create_collection(
+        Management::CollectionSpec.new do |spec|
+          spec.name = coll_name
+          spec.scope_name = scope_name
+        end,
+        Management::Options::Collection::CreateCollection.new(timeout: 80_000)
+      )
+
+      refute_nil get_collection(scope_name, coll_name)
+    end
+
+    def test_drop_collection_deprecated
+      scope_name = get_scope_name
+      coll_name = 'coll-1'
+      @collection_manager.create_scope(scope_name)
+      @collection_manager.create_collection(
+        Management::CollectionSpec.new do |spec|
+          spec.name = coll_name
+          spec.scope_name = scope_name
+        end
+      )
+
+      refute_nil get_collection(scope_name, coll_name)
+
+      @collection_manager.drop_collection(
+        Management::CollectionSpec.new do |spec|
+          spec.name = coll_name
+          spec.scope_name = scope_name
+        end,
+        Management::Options::Collection::DropCollection.new(timeout: 80_000)
+      )
+
+      assert_nil get_collection(scope_name, coll_name)
+    end
+  end
+end


### PR DESCRIPTION
## Changes

* Added `CreateCollectionSettings`, `UpdateCollectionSettings`
* Support new signatures for `create_collection` and `drop_collection` to conform to the latest RFC spec (taking `scope_name`, `collection_name`, and a `CreateCollectionSettings` instance (in the case of `create_collection`), instead of a `CollectionSpec` instance)
* Deprecated passing a `CollectionSpec` to `create_collection` and `drop_collection`
* Added `update_collection`
* Support all history retention settings in `BucketSettings`, `CreateCollectionSettings` and `UpdateCollectionSettings`
* Added tests for bucket and collection management
* Added some test helpers for retrying operations
* C++ core update

## Results
All tests pass