### PR TITLE
RCBC-450: Set value of subdoc exists to true or false if result is success or path-not-found

### DIFF
--- a/ext/couchbase.cxx
+++ b/ext/couchbase.cxx
@@ -3517,7 +3517,7 @@ cb_Backend_document_lookup_in(VALUE self, VALUE bucket, VALUE scope, VALUE colle
             if (!resp_entry.value.empty()) {
                 rb_hash_aset(entry, value_property, cb_str_new(resp_entry.value));
             }
-            if (resp_entry.ec && resp_entry.ec != couchbase::errc::key_value::path_not_found) {
+            if (resp_entry.ec) {
                 rb_hash_aset(entry,
                              error_property,
                              cb_map_error_code(resp_entry.ec,
@@ -3628,7 +3628,7 @@ cb_Backend_document_lookup_in_any_replica(VALUE self, VALUE bucket, VALUE scope,
             if (!resp_entry.value.empty()) {
                 rb_hash_aset(entry, value_property, cb_str_new(resp_entry.value));
             }
-            if (resp_entry.ec && resp_entry.ec != couchbase::errc::key_value::path_not_found) {
+            if (resp_entry.ec) {
                 rb_hash_aset(entry,
                              error_property,
                              cb_map_error_code(resp_entry.ec,
@@ -3744,7 +3744,7 @@ cb_Backend_document_lookup_in_all_replicas(VALUE self, VALUE bucket, VALUE scope
                 if (!field_entry.value.empty()) {
                     rb_hash_aset(entry, value_property, cb_str_new(field_entry.value));
                 }
-                if (field_entry.ec && field_entry.ec != couchbase::errc::key_value::path_not_found) {
+                if (field_entry.ec) {
                     rb_hash_aset(
                       entry,
                       error_property,

--- a/lib/couchbase/collection_options.rb
+++ b/lib/couchbase/collection_options.rb
@@ -169,7 +169,6 @@ module Couchbase
         field = get_field_at_index(path_or_index)
 
         raise field.error unless field.error.nil?
-        raise Error::PathNotFound, "Path is not found: #{path_or_index}" unless field.exists
 
         transcoder.decode(field.value, :json)
       end
@@ -191,7 +190,7 @@ module Couchbase
           end
         return false unless field
 
-        raise field.error unless field.error.nil?
+        raise field.error unless field.error.nil? || field.error.is_a?(Error::PathNotFound)
 
         field.exists
       end

--- a/test/subdoc_test.rb
+++ b/test/subdoc_test.rb
@@ -146,13 +146,24 @@ module Couchbase
       @collection.upsert(doc_id, {"foo" => "bar"})
 
       res = @collection.lookup_in(doc_id, [
+                                    LookupInSpec.exists("foo"),
+                                  ])
+
+      assert res.exists?(0)
+      assert res.content(0)
+    end
+
+    def test_exists_single_does_not_exist
+      doc_id = uniq_id(:foo)
+
+      @collection.upsert(doc_id, {"foo" => "bar"})
+
+      res = @collection.lookup_in(doc_id, [
                                     LookupInSpec.exists("does_not_exist"),
                                   ])
 
       refute res.exists?(0)
-      assert_raises Error::PathNotFound do
-        res.content(0)
-      end
+      refute res.content(0)
     end
 
     def test_exists_multi
@@ -166,9 +177,7 @@ module Couchbase
                                   ])
 
       refute res.exists?(0)
-      assert_raises Error::PathNotFound do
-        res.content(0)
-      end
+      refute res.content(0)
 
       assert res.exists?(1)
       assert_equal "bar", res.content(1)
@@ -1399,6 +1408,8 @@ module Couchbase
 
       assert res.exists?(0)
       refute res.exists?(1)
+      assert res.content(0)
+      refute res.content(1)
       assert_respond_to res, :replica?
     end
 
@@ -1421,6 +1432,8 @@ module Couchbase
       res.each do |entry|
         assert entry.exists?(0)
         refute entry.exists?(1)
+        assert entry.content(0)
+        refute entry.content(1)
         assert_respond_to entry, :replica?
       end
     end


### PR DESCRIPTION
Bring in changes from couchbaselabs/couchbase-cxx-client#452 and make any necessary wrapper-side changes.

When calling `#content` for an exists spec the result is the same as the result of `#exists`, provided that the subdoc operation was successful or the error was path-not-found (otherwise an error is raised), which is required to be compliant with the RFC. Previously, a PathNotFound error was raised when the path did not exist. This logic is handled by the C++ core