### PR TITLE
Show retry reasons even if no retries were attempted

### DIFF
--- a/ext/couchbase.cxx
+++ b/ext/couchbase.cxx
@@ -1013,16 +1013,14 @@ cb_map_error_code(const couchbase::key_value_error_context& ctx, const std::stri
         rb_hash_aset(enhanced_error_info, rb_id2sym(rb_intern("context")), cb_str_new(ctx.extended_error_info()->context()));
         rb_hash_aset(error_context, rb_id2sym(rb_intern("extended_error_info")), enhanced_error_info);
     }
-    if (ctx.retry_attempts() > 0) {
-        rb_hash_aset(error_context, rb_id2sym(rb_intern("retry_attempts")), INT2FIX(ctx.retry_attempts()));
-        if (!ctx.retry_reasons().empty()) {
-            VALUE retry_reasons = rb_ary_new_capa(static_cast<long>(ctx.retry_reasons().size()));
-            for (const auto& reason : ctx.retry_reasons()) {
-                auto reason_str = fmt::format("{}", reason);
-                rb_ary_push(retry_reasons, rb_id2sym(rb_intern(reason_str.c_str())));
-            }
-            rb_hash_aset(error_context, rb_id2sym(rb_intern("retry_reasons")), retry_reasons);
+    rb_hash_aset(error_context, rb_id2sym(rb_intern("retry_attempts")), INT2FIX(ctx.retry_attempts()));
+    if (!ctx.retry_reasons().empty()) {
+        VALUE retry_reasons = rb_ary_new_capa(static_cast<long>(ctx.retry_reasons().size()));
+        for (const auto& reason : ctx.retry_reasons()) {
+            auto reason_str = fmt::format("{}", reason);
+            rb_ary_push(retry_reasons, rb_id2sym(rb_intern(reason_str.c_str())));
         }
+        rb_hash_aset(error_context, rb_id2sym(rb_intern("retry_reasons")), retry_reasons);
     }
     if (ctx.last_dispatched_to()) {
         rb_hash_aset(error_context, rb_id2sym(rb_intern("last_dispatched_to")), cb_str_new(ctx.last_dispatched_to().value()));

--- a/test/crud_test.rb
+++ b/test/crud_test.rb
@@ -365,7 +365,7 @@ module Couchbase
       assert_kind_of Time, res.expiry_time
       now = Time.now
 
-      assert res.expiry_time >= now, "now: #{now} (#{now.to_i}), expiry_time: #{res.expiry_time} (#{res.expiry_time.to_i})"
+      assert_operator res.expiry_time, :>=, now, "now: #{now} (#{now.to_i}), expiry_time: #{res.expiry_time} (#{res.expiry_time.to_i})"
     end
 
     def test_expiry_option_as_time_instance
@@ -601,7 +601,7 @@ module Couchbase
 
       assert_equal(expected, res.content, "expected result do not include field17, field18")
       assert_kind_of(Time, res.expiry_time)
-      assert(res.expiry_time > Time.now)
+      assert_operator(res.expiry_time, :>, Time.now)
     end
 
     def test_upsert_get_projection_missing_path

--- a/test/scan_test.rb
+++ b/test/scan_test.rb
@@ -75,7 +75,7 @@ module Couchbase
 
         assert_equal(ids_only, item.id_only)
       end
-      assert(items.size <= limit)
+      assert_operator(items.size, :<=, limit)
 
       return if ids_only
 

--- a/test/search_test.rb
+++ b/test/search_test.rb
@@ -100,7 +100,7 @@ module Couchbase
       end
       warn "search with at_plus took #{attempts} attempts, probably server bug" if attempts > 1
 
-      assert attempts < 20, "it is very suspicious that search with at_plus took more than 20 attempts (#{attempts})"
+      assert_operator attempts, :<, 20, "it is very suspicious that search with at_plus took more than 20 attempts (#{attempts})"
     end
 
     def test_doc_id_search_query
@@ -136,7 +136,7 @@ module Couchbase
       end
       warn "search took #{attempts} attempts, probably a server bug" if attempts > 1
 
-      assert attempts < 20, "it is very suspicious that search took more than 20 attempts (#{attempts})"
+      assert_operator attempts, :<, 20, "it is very suspicious that search took more than 20 attempts (#{attempts})"
     end
   end
 end

--- a/test/subdoc_test.rb
+++ b/test/subdoc_test.rb
@@ -1197,7 +1197,7 @@ module Couchbase
       res = @collection.get(doc_id, options)
 
       assert_kind_of Time, res.expiry_time
-      assert res.expiry_time > Time.now
+      assert_operator res.expiry_time, :>, Time.now
     end
 
     def test_more_than_16_entries


### PR DESCRIPTION
The `retry_reasons` field in the core's error context can be populated even if no retries were attempted. Always include it in the corresponding Ruby error's `context` if it is populated