### PR TITLE
Ensure that truncating keys in CouchbaseStore preserves the validity of their encoding

### DIFF
--- a/lib/active_support/cache/couchbase_store.rb
+++ b/lib/active_support/cache/couchbase_store.rb
@@ -294,14 +294,14 @@ module ActiveSupport
 
       # Truncate keys that exceed 250 characters
       def normalize_key(key, options)
-        truncate_key super&.b
+        truncate_key super
       end
 
       def truncate_key(key)
         if key && key.bytesize > MAX_KEY_BYTESIZE
           suffix = ":sha2:#{::Digest::SHA2.hexdigest(key)}"
           truncate_at = MAX_KEY_BYTESIZE - suffix.bytesize
-          "#{key.byteslice(0, truncate_at)}#{suffix}"
+          "#{key.mb_chars.limit(truncate_at)}#{suffix}"
         else
           key
         end

--- a/test/active_support/behaviors/encoded_key_cache_behavior.rb
+++ b/test/active_support/behaviors/encoded_key_cache_behavior.rb
@@ -33,4 +33,20 @@ module EncodedKeyCacheBehavior
     assert @cache.write(key, "1", raw: true)
     assert_equal Encoding::UTF_8, key.encoding
   end
+
+  def test_very_long_utf8_key
+    key = ("a"*249 + "\xC3\xBC").force_encoding(Encoding::UTF_8)
+    assert @cache.write(key, "1", raw: true)
+    assert_equal Encoding::UTF_8, key.encoding
+    assert key.valid_encoding?
+    assert key.bytesize > 250
+  end
+
+  def test_normalize_key
+    key = ("a"*249 + "\xC3\xBC").force_encoding(Encoding::UTF_8)
+    normalized_key = @cache.send(:normalize_key, key, nil)
+    assert_equal Encoding::UTF_8, normalized_key.encoding
+    assert normalized_key.valid_encoding?
+    assert normalized_key.bytesize <= 250
+  end
 end


### PR DESCRIPTION
* Instead of using `byteslice` use `limit` from active support than ensures that characters are not broken
* Don't force the encoding to ASCII in `normalize_key`
* Add tests to check that truncating keys works as expected