### PR TITLE
RCBC-468: Support for maxTTL value of -1 for collection 'no expiry'

### DIFF
--- a/ext/couchbase.cxx
+++ b/ext/couchbase.cxx
@@ -5461,7 +5461,7 @@ cb_Backend_scope_get_all(VALUE self, VALUE bucket_name, VALUE options)
                 VALUE collection = rb_hash_new();
                 rb_hash_aset(collection, rb_id2sym(rb_intern("uid")), ULL2NUM(c.uid));
                 rb_hash_aset(collection, rb_id2sym(rb_intern("name")), cb_str_new(c.name));
-                rb_hash_aset(collection, rb_id2sym(rb_intern("max_expiry")), ULONG2NUM(c.max_expiry));
+                rb_hash_aset(collection, rb_id2sym(rb_intern("max_expiry")), LONG2NUM(c.max_expiry));
                 if (c.history.has_value()) {
                     rb_hash_aset(collection, rb_id2sym(rb_intern("history")), c.history.value() ? Qtrue : Qfalse);
                 }
@@ -5618,7 +5618,12 @@ cb_Backend_collection_create(VALUE self, VALUE bucket_name, VALUE scope_name, VA
         if (!NIL_P(settings)) {
             if (VALUE max_expiry = rb_hash_aref(settings, rb_id2sym(rb_intern("max_expiry"))); !NIL_P(max_expiry)) {
                 if (TYPE(max_expiry) == T_FIXNUM) {
-                    req.max_expiry = FIX2UINT(max_expiry);
+                    req.max_expiry = FIX2INT(max_expiry);
+                    if (req.max_expiry < -1) {
+                        throw ruby_exception(
+                          eInvalidArgument,
+                          rb_sprintf("collection max expiry must be greater than or equal to -1, given %+" PRIsVALUE, max_expiry));
+                    }
                 } else {
                     throw ruby_exception(rb_eArgError,
                                          rb_sprintf("collection max expiry must be an Integer, given %+" PRIsVALUE, max_expiry));
@@ -5674,7 +5679,12 @@ cb_Backend_collection_update(VALUE self, VALUE bucket_name, VALUE scope_name, VA
         if (!NIL_P(settings)) {
             if (VALUE max_expiry = rb_hash_aref(settings, rb_id2sym(rb_intern("max_expiry"))); !NIL_P(max_expiry)) {
                 if (TYPE(max_expiry) == T_FIXNUM) {
-                    req.max_expiry = FIX2UINT(max_expiry);
+                    req.max_expiry = FIX2INT(max_expiry);
+                    if (req.max_expiry < -1) {
+                        throw ruby_exception(
+                          eInvalidArgument,
+                          rb_sprintf("collection max expiry must be greater than or equal to -1, given %+" PRIsVALUE, max_expiry));
+                    }
                 } else {
                     throw ruby_exception(rb_eArgError,
                                          rb_sprintf("collection max expiry must be an Integer, given %+" PRIsVALUE, max_expiry));

--- a/lib/couchbase/management/collection_manager.rb
+++ b/lib/couchbase/management/collection_manager.rb
@@ -383,7 +383,7 @@ module Couchbase
 
     class CreateCollectionSettings
       # @return [Integer, nil] time in seconds of the maximum expiration time for new documents in the collection
-      # (set to +nil+ to disable it)
+      # (set to +nil+ to use the bucket-level setting, and to +-1+ set it to no-expiry)
       attr_accessor :max_expiry
 
       # @return [Boolean, nil] whether history retention override should be enabled in the collection (set to +nil+ to
@@ -410,11 +410,11 @@ module Couchbase
 
     class UpdateCollectionSettings
       # @return [Integer, nil] time in seconds of the maximum expiration time for new documents in the collection
-      # (set to +nil+ to disable it)
+      # (set to +nil+ to not update it, and to +-1+ set it to no-expiry)
       attr_accessor :max_expiry
 
       # @return [Boolean, nil] whether history retention override should be enabled in the collection (set to +nil+ to
-      # default to the bucket-level setting)
+      # not update it)
       attr_accessor :history
 
       def initialize(max_expiry: nil, history: nil)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -110,6 +110,10 @@ class ServerVersion
   def supports_update_collection_max_expiry?
     @version >= Gem::Version.create("7.5.0")
   end
+
+  def supports_collection_max_expiry_set_to_no_expiry?
+    @version >= Gem::Version.create("7.6.0")
+  end
 end
 
 require "couchbase"


### PR DESCRIPTION
* Change conversions of `max_expiry` from Ruby to C++ and vice versa to take into account that max_expiry is now a signed integer in the collections API
* Raise an `InvalidArgument` error if `max_expiry` is less than `-1`
* Add tests for setting `max_expiry` to `-1` and for invalid values in both `update_collection` and `create_collection`