### PR TITLE
RCBC-472: Ping management service when specified in options

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -202,7 +202,7 @@ task :cache_cxx_dependencies do
   rm_rf(cpm_cache_dir, verbose: true)
 
   untar = ["tar", "-x"]
-  untar << "--force-local" unless RUBY_PLATFORM.match?(/darwin/)
+  untar << "--force-local" unless RUBY_PLATFORM.include?('darwin')
 
   puts("-----> verify that tarball works as a cache for CPM")
   cxx_core_build_dir = Dir.mktmpdir("cxx_build_")

--- a/ext/couchbase.cxx
+++ b/ext/couchbase.cxx
@@ -2472,6 +2472,10 @@ cb_Backend_ping(VALUE self, VALUE bucket, VALUE options)
                     selected_services.insert(couchbase::core::service_type::search);
                 } else if (entry == rb_id2sym(rb_intern("views"))) {
                     selected_services.insert(couchbase::core::service_type::view);
+                } else if (entry == rb_id2sym(rb_intern("management"))) {
+                    selected_services.insert(couchbase::core::service_type::management);
+                } else if (entry == rb_id2sym(rb_intern("eventing"))) {
+                    selected_services.insert(couchbase::core::service_type::eventing);
                 }
             }
         }
@@ -2510,7 +2514,7 @@ cb_Backend_ping(VALUE self, VALUE bucket, VALUE options)
                     type = rb_id2sym(rb_intern("views"));
                     break;
                 case couchbase::core::service_type::management:
-                    type = rb_id2sym(rb_intern("mgmt"));
+                    type = rb_id2sym(rb_intern("management"));
                     break;
                 case couchbase::core::service_type::eventing:
                     type = rb_id2sym(rb_intern("eventing"));

--- a/test/diagnostics_test.rb
+++ b/test/diagnostics_test.rb
@@ -1,0 +1,48 @@
+#  Copyright 2024. Couchbase, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+require_relative "test_helper"
+module Couchbase
+  class DiagnosticsTest < Minitest::Test
+    include Couchbase::TestUtilities
+
+    def setup
+      skip("#{name}: The #{Couchbase::Protostellar::NAME} protocol does not support ping/diagnostics") if env.protostellar?
+
+      connect
+    end
+
+    def teardown
+      disconnect
+    end
+
+    def test_cluster_ping_multiple_services
+      service_types = [:kv, :query, :search, :management]
+      res = @cluster.ping(Options::Ping.new(service_types: service_types))
+
+      assert_equal service_types.size, res.services.size
+      service_types.each do |s|
+        assert_includes res.services.keys, s
+      end
+    end
+
+    def test_cluster_ping_single_service
+      [:kv, :query, :search, :management].each do |service_type|
+        res = @cluster.ping(Options::Ping.new(service_types: [service_type]))
+
+        assert_equal 1, res.services.size
+        assert_equal service_type, res.services.keys[0]
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Changes
* For the `service_types` option map `:management` and `:eventing` to the corresponding C++ enum values
* In `PingResult`, use the correct symbol for the key of the management service info