### PR TITLE
Mark `couchbase2://` scheme as uncommitted & update API 3.5 stability

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,1 +1,3 @@
 --no-progress --output-dir doc/couchbase-ruby-client-master lib - README.md
+--tag couchbase.stability:"Stability"
+--transitive-tag couchbase.stability

--- a/lib/couchbase.rb
+++ b/lib/couchbase.rb
@@ -18,3 +18,11 @@ require "couchbase/logger"
 require "couchbase/cluster"
 
 require "couchbase/railtie" if defined?(Rails)
+
+# @!macro uncommitted
+#   @couchbase.stability
+#     Uncommitted: This API may change in the future.
+#
+# @!macro volatile
+#   @couchbase.stability
+#     Volatile: This API is subject to change at any time.

--- a/lib/couchbase/cluster.rb
+++ b/lib/couchbase/cluster.rb
@@ -63,6 +63,8 @@ module Couchbase
     #
     # @see https://docs.couchbase.com/server/current/manage/manage-security/configure-client-certificates.html
     #
+    # @note The +couchbase2://+ scheme is currently at stability _uncommitted_
+    #
     # @return [Cluster]
     def self.connect(connection_string_or_config, *options)
       connection_string = if connection_string_or_config.is_a?(Configuration)

--- a/lib/couchbase/cluster.rb
+++ b/lib/couchbase/cluster.rb
@@ -195,8 +195,6 @@ module Couchbase
 
     # Performs a request against the Full Text Search (FTS) service.
     #
-    # @api volatile
-    #
     # @param [String] index_name the name of the search index
     # @param [SearchRequest] search_request the request
     # @param [Options::Search] options the custom options for this search request

--- a/lib/couchbase/collection.rb
+++ b/lib/couchbase/collection.rb
@@ -595,8 +595,6 @@ module Couchbase
 
     # Performs a key-value scan operation on the collection
     #
-    # @api uncommitted
-    #
     # @param [RangeScan, PrefixScan, SamplingScan] scan_type the type of the scan
     # @param [Options::Scan] options request customization
     #

--- a/lib/couchbase/errors.rb
+++ b/lib/couchbase/errors.rb
@@ -63,7 +63,7 @@ module Couchbase
 
     # Indicates that the user has insufficient permissions to perform the operation
     #
-    # @api uncommitted
+    # @!macro uncommitted
     class PermissionDenied < CouchbaseError
     end
 

--- a/lib/couchbase/key_value_scan.rb
+++ b/lib/couchbase/key_value_scan.rb
@@ -20,8 +20,6 @@ module Couchbase
 
     # Creates an instance of a ScanTerm
     #
-    # @api uncommitted
-    #
     # @param [String] term the key pattern of this term
     # @param [Boolean] exclusive specifies if this term is excluded while scanning, the bounds are included by default
     def initialize(term, exclusive: false)
@@ -44,8 +42,6 @@ module Couchbase
     attr_accessor :to # @return [ScanTerm, nil]
 
     # Creates an instance of a RangeScan scan type
-    #
-    # @api uncommitted
     #
     # @param [ScanTerm, String, nil] from the lower bound of the range, if set
     # @param [ScanTerm, String, nil] to the upper bound of the range, if set
@@ -80,8 +76,6 @@ module Couchbase
 
     # Creates an instance of a PrefixScan scan type
     #
-    # @api uncommitted
-    #
     # @param [String, nil] prefix the prefix all document keys should start with
     def initialize(prefix)
       @prefix = prefix
@@ -102,8 +96,6 @@ module Couchbase
     attr_accessor :seed # @return [Integer, nil]
 
     # Creates an instance of a SamplingScan scan type
-    #
-    # @api uncommitted
     #
     # @param [Integer] limit the maximum number of documents the sampling scan can return
     # @param [Integer, nil] seed the seed used for the random number generator that selects the documents. If not set,

--- a/lib/couchbase/management/scope_search_index_manager.rb
+++ b/lib/couchbase/management/scope_search_index_manager.rb
@@ -14,7 +14,6 @@
 
 module Couchbase
   module Management
-    # @api volatile
     class ScopeSearchIndexManager
       alias inspect to_s
 

--- a/lib/couchbase/management/search_index_manager.rb
+++ b/lib/couchbase/management/search_index_manager.rb
@@ -103,7 +103,7 @@ module Couchbase
 
       # Retrieves metrics, timings and counters for a given index
       #
-      # @api uncommitted
+      # @!macro uncommitted
       #
       # @param [String] index_name name of the index
       # @param [GetIndexStatsOptions] options
@@ -120,7 +120,7 @@ module Couchbase
       # Retrieves statistics on search service. Information is provided on documents, partition indexes, mutations,
       # compactions, queries, and more.
       #
-      # @api uncommitted
+      # @!macro uncommitted
       #
       # @param [GetIndexStatsOptions] options
       #

--- a/lib/couchbase/protostellar.rb
+++ b/lib/couchbase/protostellar.rb
@@ -17,6 +17,7 @@
 require_relative "protostellar/cluster"
 
 module Couchbase
+  # @api private
   module Protostellar
     NAME = "couchbase2"
     SCHEMES = %w[couchbase2 protostellar].freeze

--- a/lib/couchbase/scope.rb
+++ b/lib/couchbase/scope.rb
@@ -149,8 +149,6 @@ module Couchbase
 
     # Performs a request against the Full Text Search (FTS) service.
     #
-    # @api volatile
-    #
     # @param [String] index_name the name of the search index
     # @param [SearchRequest] search_request the request
     # @param [Options::Search] options the custom options for this search request
@@ -162,8 +160,6 @@ module Couchbase
       convert_search_result(resp, options)
     end
 
-    # @api volatile
-    #
     # @return [Management::ScopeSearchIndexManager]
     def search_indexes
       Management::ScopeSearchIndexManager.new(@backend, @bucket_name, @name)

--- a/lib/couchbase/search_options.rb
+++ b/lib/couchbase/search_options.rb
@@ -24,7 +24,7 @@ module Couchbase
     #   Will run a +VectorSearch+
     #   @param [VectorSearch] vector_search
     #
-    #   @api uncommitted
+    #   @!macro uncommitted
     def initialize(search)
       case search
       when SearchQuery
@@ -56,7 +56,7 @@ module Couchbase
     #
     # @return [SearchRequest] for chaining purposes
     #
-    # @api uncommitted
+    # @!macro uncommitted
     def vector_search(query)
       raise Error::InvalidArgument, "A VectorSearch has already been specified" unless @vector_search.nil?
 
@@ -687,7 +687,7 @@ module Couchbase
     #
     # @return [GeoPolygonQuery]
     #
-    # @api uncommitted
+    # @!macro uncommitted
     def self.geo_polygon(coordinates, &block)
       GeoPolygonQuery.new(coordinates, &block)
     end
@@ -1041,10 +1041,10 @@ module Couchbase
     end
   end
 
-  # @api uncommitted
+  # @!macro uncommitted
   class VectorSearch
     # Constructs a +VectorSearch+ instance, which allows one or more individual vector queries to be executed.
-    # #
+    #
     # @param [VectorQuery, Array<VectorQuery>] vector_queries vector queries/query to execute
     # @param [Options::VectorSearch] options
     def initialize(vector_queries, options = Options::VectorSearch::DEFAULT)
@@ -1058,7 +1058,7 @@ module Couchbase
     end
   end
 
-  # @api uncommitted
+  # @!macro uncommitted
   class VectorQuery
     # @return [Integer, nil]
     attr_accessor :num_candidates

--- a/lib/couchbase/search_options.rb
+++ b/lib/couchbase/search_options.rb
@@ -13,7 +13,6 @@
 #  limitations under the License.
 
 module Couchbase
-  # @api volatile
   class SearchRequest
     # Creates a search request, used to perform operations against the Full Text Search (FTS) Couchbase service.
     #
@@ -24,6 +23,8 @@ module Couchbase
     # @overload new(vector_search)
     #   Will run a +VectorSearch+
     #   @param [VectorSearch] vector_search
+    #
+    #   @api uncommitted
     def initialize(search)
       case search
       when SearchQuery
@@ -54,6 +55,8 @@ module Couchbase
     # @param [VectorSearch] query
     #
     # @return [SearchRequest] for chaining purposes
+    #
+    # @api uncommitted
     def vector_search(query)
       raise Error::InvalidArgument, "A VectorSearch has already been specified" unless @vector_search.nil?
 
@@ -1038,7 +1041,7 @@ module Couchbase
     end
   end
 
-  # @api volatile
+  # @api uncommitted
   class VectorSearch
     # Constructs a +VectorSearch+ instance, which allows one or more individual vector queries to be executed.
     # #
@@ -1055,7 +1058,7 @@ module Couchbase
     end
   end
 
-  # @api volatile
+  # @api uncommitted
   class VectorQuery
     # @return [Integer, nil]
     attr_accessor :num_candidates


### PR DESCRIPTION
* Added note for stability of `couchbase2://`
* Updated stability for API 3.5 features
* Added a custom stability tag so that it's visible in the API reference.