### PR TITLE
RCBC-476: FeatureNotAvailable for cb2 ping/diagnostics

### DIFF
--- a/lib/couchbase/protostellar/bucket.rb
+++ b/lib/couchbase/protostellar/bucket.rb
@@ -46,6 +46,10 @@ module Couchbase
       def collections
         Management::CollectionManager.new(client: @client, bucket_name: @name)
       end
+
+      def ping(_options = Options::Ping::DEFAULT)
+        raise Couchbase::Error::FeatureNotAvailable, "The #{Protostellar::NAME} protocol does not support ping"
+      end
     end
   end
 end

--- a/lib/couchbase/protostellar/cluster.rb
+++ b/lib/couchbase/protostellar/cluster.rb
@@ -144,6 +144,14 @@ module Couchbase
         ResponseConverter::Search.to_search_result(resp, options)
       end
 
+      def diagnostics(_options = Options::Diagnostics::DEFAULT)
+        raise Couchbase::Error::FeatureNotAvailable, "The #{Protostellar::NAME} protocol does not support diagnostics"
+      end
+
+      def ping(_options = Options::Ping::DEFAULT)
+        raise Couchbase::Error::FeatureNotAvailable, "The #{Protostellar::NAME} protocol does not support ping"
+      end
+
       private
 
       def initialize(host, options = ConnectOptions.new)


### PR DESCRIPTION
The current ping/diagnostics response format does not make sense for `couchbase2`, so it will not be supported for now. This change adds ping/diagnostics methods for `couchbase2` that raise `Error::FeatureNotAvailable`.