### PR TITLE
RCBC-482: Only expand MutateIn macros when the relevant symbols are used as values

### DIFF
--- a/lib/couchbase/subdoc.rb
+++ b/lib/couchbase/subdoc.rb
@@ -272,7 +272,8 @@ module Couchbase
         else
           param
         end
-      @expand_macros = [CAS, SEQ_NO, VALUE_CRC32C].include?(@param)
+      # Only set expand_macros when a the value is a symbol that matches one of the macros
+      @expand_macros = [:cas, :seq_no, :sequence_number, :value_crc, :value_crc32c].include?(param)
       @xattr = true if @expand_macros
       return if @param.nil?
 


### PR DESCRIPTION
`@expand_macros` should only be set to `true` when the macros are set using the symbols.

From the API documentation:
> When symbol specified and it is matches to known macro, it will be expanded

This fixes the `insertExpandMacroXattrDoNotFlag` failure in FIT.