### PR TITLE
RCBC-489: Support for base64 encoded vector types

### DIFF
--- a/lib/couchbase/search_options.rb
+++ b/lib/couchbase/search_options.rb
@@ -1071,13 +1071,23 @@ module Couchbase
 
     # Constructs a +VectorQuery+ instance
     #
-    # @param [String] vector_field_name the document field that contains the vector.
-    # @param [Array<Float>] vector_query the vector query to run.
+    # @overload initialize(vector_field_name, vector_query)
+    #   @param [String] vector_field_name the document field that contains the vector.
+    #   @param [Array<Float>] vector_query the vector query.
     #
-    # @yieldparam [MatchPhraseQuery] self
+    # @overload initialize(vector_field_name, base64_vector_query)
+    #   @param [String] vector_field_name the document field that contains the vector.
+    #   @param [String] base64_vector_query the vector query represented as a base64-encoded sequence of little-endian IEEE 754 floats.
+    #
+    # @yieldparam [VectorQuery] self
     def initialize(vector_field_name, vector_query)
       @vector_field_name = vector_field_name
-      @vector_query = vector_query
+
+      if vector_query.respond_to?(:to_str)
+        @base64_vector_query = vector_query.to_str
+      else
+        @vector_query = vector_query
+      end
 
       yield self if block_given?
     end
@@ -1092,6 +1102,7 @@ module Couchbase
       {
         field: @vector_field_name,
         vector: @vector_query,
+        vector_base64: @base64_vector_query,
         k: num_candidates || 3,
         boost: boost,
       }.compact

--- a/test/search_test.rb
+++ b/test/search_test.rb
@@ -237,6 +237,15 @@ module Couchbase
       assert_equal SearchQuery.match_none.to_json, enc_query
     end
 
+    def test_vector_search_query_base64
+      base64_query = "aOeYBEXJ4kI="
+      enc_vector_query = VectorQuery.new("foo", base64_query).to_h
+
+      refute enc_vector_query.key?(:vector)
+      assert enc_vector_query.key?(:vector_base64)
+      assert_equal enc_vector_query[:vector_base64], base64_query
+    end
+
     def test_vector_search_not_supported
       skip("#{name}: Server supports vector search") if !env.protostellar? && env.server_version.supports_vector_search?
 


### PR DESCRIPTION
## Motivation

In 7.6.2, the server will support base64 encoding of vectors in addition to array type "vector". The new encoding type will be accepted via the parameter "vector_base64" in the vector search query.

## Changes

* Add new overload for the constructor of `VectorQuery` that accepts a string which represents a base64 encoded sequence of little-endian IEEE 754 floats. This is then forwarded as-is in the vector search query using the"vector_base64" parameter.
* Core update to `f72a089` which includes raising `FeatureNotAvailable` in `SearchIndexManager#upsert_index` & `ScopeSearchIndexManager#upsert_index` when upserting indexes with vector definitions to servers that do not support it.

## Results

All vector search tests in FIT pass