### PR TITLE
RCBC-492: InvalidArgument when vector is empty

### DIFF
--- a/lib/couchbase/search_options.rb
+++ b/lib/couchbase/search_options.rb
@@ -1099,13 +1099,23 @@ module Couchbase
               "Number of candidates must be at least 1, #{num_candidates} given"
       end
 
-      {
+      h = {
         field: @vector_field_name,
         vector: @vector_query,
         vector_base64: @base64_vector_query,
         k: num_candidates || 3,
         boost: boost,
       }.compact
+
+      raise Error::InvalidArgument, "The vector cannot be nil" if !h.include?(:vector) && !h.include?(:vector_base64)
+      raise Error::InvalidArgument, "The vector query cannot be an empty array" if h.include?(:vector) && h[:vector].empty?
+
+      if h.include?(:vector_base64) && h[:vector_base64].empty?
+        raise Error::InvalidArgument,
+              "The base64-encoded vector query cannot be empty"
+      end
+
+      h
     end
 
     # @api private

--- a/test/search_test.rb
+++ b/test/search_test.rb
@@ -220,6 +220,24 @@ module Couchbase
       end
     end
 
+    def test_vector_query_empty
+      vector_query = VectorQuery.new("foo", [])
+
+      assert_raises(Error::InvalidArgument) { vector_query.to_json }
+    end
+
+    def test_base64_vector_query_empty
+      vector_query = VectorQuery.new("foo", "")
+
+      assert_raises(Error::InvalidArgument) { vector_query.to_json }
+    end
+
+    def test_vector_query_nil
+      vector_query = VectorQuery.new("foo", nil)
+
+      assert_raises(Error::InvalidArgument) { vector_query.to_json }
+    end
+
     def test_vector_query_invalid_candidate_number
       vector_query = VectorQuery.new("foo", [-1.1, 1.2]) do |q|
         q.num_candidates = 0


### PR DESCRIPTION
From the RFC:
> The current size limit for the vector is 2048 elements, but this will not be enforced on the SDK side. Either vector or vector_base64 must be non-empty though, and if not the SDK will raise InvalidArgument.