### PR TITLE
RCBC-513: Forward prepend/append CAS to core

### DIFF
--- a/ext/rcb_crud.cxx
+++ b/ext/rcb_crud.cxx
@@ -652,6 +652,7 @@ cb_Backend_document_append(VALUE self,
     couchbase::append_options opts;
     set_timeout(opts, options);
     set_durability(opts, options);
+    set_cas(opts, options);
 
     auto f = cluster.bucket(cb_string_new(bucket))
                .scope(cb_string_new(scope))
@@ -698,6 +699,7 @@ cb_Backend_document_prepend(VALUE self,
     couchbase::prepend_options opts;
     set_timeout(opts, options);
     set_durability(opts, options);
+    set_cas(opts, options);
 
     auto f = cluster.bucket(cb_string_new(bucket))
                .scope(cb_string_new(scope))


### PR DESCRIPTION
## Motivation

Previously the append and prepend requests in the C++ core did not have a field for CAS. This meant that the relevant option in append/prepend options was being ignored.

## Changes

* Update C++ core
* Set the CAS option in the C++ wrapper code

## Results

Relevant tests in FIT pass.