### PR TITLE
RCBC-517: Support vector search prefilter

### DIFF
--- a/lib/couchbase/search_options.rb
+++ b/lib/couchbase/search_options.rb
@@ -1112,8 +1112,9 @@ module Couchbase
         vector_base64: @base64_vector_query,
         k: num_candidates || 3,
         boost: boost,
-        filter: prefilter.to_h,
       }.compact
+
+      h[:filter] = prefilter.to_h unless prefilter.nil?
 
       raise Error::InvalidArgument, "The vector cannot be nil" if !h.include?(:vector) && !h.include?(:vector_base64)
       raise Error::InvalidArgument, "The vector query cannot be an empty array" if h.include?(:vector) && h[:vector].empty?


### PR DESCRIPTION
## Motivation

Prefilters allow users to run vector queries on a subset of the vector index.

## Changes

* Add a prefilter option on `VectorQuery` allowing users to specify the search query that defines the filter.
* [FIX] Forward block given to `SearchQuery.boolean_field` to the constructor of `BooleanFieldQuery`

## Results

All tests in FIT's VectorSearchPrefilterTest pass
