### PR TITLE
Test helper: Fix simplecov error

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,6 +22,7 @@ else
 end
 
 begin
+  require "simplecov"
   require "simplecov-cobertura"
   SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
   SimpleCov.start


### PR DESCRIPTION
simplecov-cobertura v3 doesn't do the `require "simplecov"`. We should now do it ourselves.