### PR TITLE
RCBC-518: Add way to disable enterprise analytics check programmatically

### DIFF
--- a/ext/rcb_extras.cxx
+++ b/ext/rcb_extras.cxx
@@ -20,6 +20,7 @@
 #include <core/io/dns_client.hxx>
 #include <core/io/dns_config.hxx>
 #include <core/logger/logger.hxx>
+#include <core/operations/document_analytics.hxx>
 #include <core/operations/management/cluster_developer_preview_enable.hxx>
 #include <core/operations/management/collections_manifest_get.hxx>
 #include <core/utils/connection_string.hxx>
@@ -318,6 +319,13 @@ cb_Backend_path_escape(VALUE self, VALUE data)
   return cb_str_new(encoded);
 }
 
+VALUE
+cb_Backend_allow_enterprise_analytics(VALUE self)
+{
+  core::operations::analytics_request::allow_enterprise_analytics = true;
+  return Qnil;
+}
+
 int
 cb_for_each_form_encode_value(VALUE key, VALUE value, VALUE arg)
 {
@@ -390,5 +398,7 @@ init_extras(VALUE cBackend)
   rb_define_singleton_method(cBackend, "query_escape", cb_Backend_query_escape, 1);
   rb_define_singleton_method(cBackend, "path_escape", cb_Backend_path_escape, 1);
   rb_define_singleton_method(cBackend, "form_encode", cb_Backend_form_encode, 1);
+  rb_define_singleton_method(
+    cBackend, "allow_enterprise_analytics", cb_Backend_allow_enterprise_analytics, 0);
 }
 } // namespace couchbase::ruby


### PR DESCRIPTION
Can be used as follows:
```ruby
irb(main):002> Couchbase::Backend::allow_enterprise_analytics 
=> nil
irb(main):003> cluster = Couchbase::Cluster::connect('couchbase://192.168.106.132', 'Administrator', 'password')
=> #<Couchbase::Cluster:0x00000001214146d8>
irb(main):004> cluster.analytics_query('SELECT 1=1')
=> 
#<Couchbase::Cluster::AnalyticsResult:0x0000000121236848
 @meta_data=
  #<Couchbase::Cluster::AnalyticsMetaData:0x00000001212366b8
   @client_context_id="4fabd0-8a39-f149-49e2-86568450b938f7",
   @metrics=#<Couchbase::Cluster::AnalyticsMetrics:0x0000000121236488 @elapsed_time=20331816, @error_count=0, @execution_time=2.000000001879481, @processed_objects=0, @result_count=1, @result_size=11, @warning_count=0>,
   @request_id="2b0f30b6-0973-4e66-9ff8-16d40454bbc1",
   @signature={"*"=>"*"},
   @status=:success>,
 @rows=["{\"$1\":true}"],
 @transcoder=#<Couchbase::JsonTranscoder:0x000000011e813520>>
```

The default behaviour would be:
```ruby
irb(main):002> cluster = Couchbase::Cluster::connect('couchbase://192.168.106.132', 'Administrator', 'password')
=> #<Couchbase::Cluster:0x000000013a012f08>
irb(main):003> 
irb(main):004> cluster.analytics_query('SELECT 1=1')
[2025-08-05 16:34:18.804] 13353ms [erro] [72444,13909398] This analytics cluster cannot be used with this SDK, which is intended for use with operational clusters. For this cluster, an Enterprise Analytics SDK should be used. 
/Users/dimitrischristodoulou/projects/couchbase-ruby-client/lib/couchbase/cluster.rb:150:in `document_analytics': unable to execute analytics query: feature_not_available (15), context={"error":"15, feature_not_available (15)","client_context_id":"","statement":"SELECT 1=1","parameters":"","http_status":0,"http_body":""} (Couchbase::Error::FeatureNotAvailable)
```

Depends on https://github.com/couchbase/couchbase-cxx-client/pull/810