### PR TITLE
Fix rubocop error & warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 inherit_from: .rubocop_todo.yml
-require:
+plugins:
   - rubocop-minitest
   - rubocop-packaging
   - rubocop-performance

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -31,7 +31,7 @@ Metrics/ClassLength:
 Metrics/BlockLength:
   Enabled: false
 
-Naming/PredicateName:
+Naming/PredicatePrefix:
   Enabled: false
 
 Style/AccessorGrouping:

--- a/lib/couchbase/protostellar/response_converter/search.rb
+++ b/lib/couchbase/protostellar/response_converter/search.rb
@@ -38,7 +38,7 @@ module Couchbase
 
         def self.convert_search_row(proto_row, options)
           Couchbase::Cluster::SearchRow.new do |r|
-            r.instance_variable_set(:@fields, (proto_row.fields.to_h.transform_values { |v| JSON.parse(v) }).to_json)
+            r.instance_variable_set(:@fields, proto_row.fields.to_h.transform_values { |v| JSON.parse(v) }.to_json)
             r.transcoder = options.transcoder
             r.index = proto_row.index
             r.id = proto_row.id


### PR DESCRIPTION
Fix warnings:
```
rubocop-[...] extension supports plugin, specify `plugins: rubocop-[...]` instead of `require: rubocop-[...]` in /[...]/couchbase-ruby-client/.rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.
```
```
Warning: The `Naming/PredicateName` cop has been renamed to `Naming/PredicatePrefix`.
(obsolete configuration found in .rubocop_todo.yml, please update it)
```
and error:
```
lib/couchbase/protostellar/response_converter/search.rb:41:47: C: [Correctable] Style/RedundantParentheses: Don't use parentheses around a method call.
            r.instance_variable_set(:@fields, (proto_row.fields.to_h.transform_values { |v| JSON.parse(v) }).to_json)
                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```