### PR TITLE
Release 3.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository contains the third generation of the official Couchbase SDK for 
 
 ## Support and Feedback
 
-If you find an issue, please file it in [our JIRA issue tracker](https://couchbase.com/issues/browse/RCBC). Also you are
+If you find an issue, please file it in [our JIRA issue tracker](https://jira.issues.couchbase.com/browse/RCBC). Also you are
 always welcome on [our forum](https://forums.couchbase.com/c/ruby-sdk) and [Discord](https://discord.com/invite/sQ5qbPZuTh).
 
 Please attach version information to the ticket/post. To obtain this information, use the following command:
@@ -23,7 +23,7 @@ The library has been tested with MRI 3.2, 3.3, 3.4 and 4.0. Supported platforms 
 Add this line to your application's Gemfile:
 
 ```ruby
-gem "couchbase", "3.7.0"
+gem "couchbase", "3.8.0"
 ```
 
 And then execute:

--- a/couchbase-opentelemetry/README.md
+++ b/couchbase-opentelemetry/README.md
@@ -55,7 +55,7 @@ meter = Couchbase::OpenTelemetry::Meter.new(meter_provider)
 
 # Configure tracer and meter in cluster options
 options = Couchbase::Options::Cluster.new(
-    authenticator: Couchbase::PasswordAuthenticator.new("Administrator", "password")
+    authenticator: Couchbase::PasswordAuthenticator.new("Administrator", "password"),
     tracer: tracer,
     meter: meter
 )

--- a/couchbase-opentelemetry/lib/couchbase/opentelemetry/version.rb
+++ b/couchbase-opentelemetry/lib/couchbase/opentelemetry/version.rb
@@ -17,6 +17,6 @@
 module Couchbase
   module OpenTelemetry
     # Version of the Couchbase OpenTelemetry integration gem
-    VERSION = "0.1.0"
+    VERSION = "3.8.0"
   end
 end

--- a/lib/couchbase/version.rb
+++ b/lib/couchbase/version.rb
@@ -21,5 +21,5 @@ module Couchbase
   #   $ ruby -rcouchbase -e 'pp Couchbase::VERSION'
   #   {:sdk=>"3.4.0", :ruby_abi=>"3.1.0", :revision=>"416fe68e6029ec8a4c40611cf6e6b30d3b90d20f"}
   VERSION = {} unless defined?(VERSION) # rubocop:disable Style/MutableConstant
-  VERSION.update(:sdk => "3.7.0")
+  VERSION.update(:sdk => "3.8.0")
 end


### PR DESCRIPTION
Bump couchbase and couchbase-opentelemetry gem versions to 3.8.0, update the README gem reference and JIRA link, and fix a missing comma in the couchbase-opentelemetry README code snippet.