### PR TITLE
RCBC-542: Forward CAS to C++ Core in Append/Prepend

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,8 +36,8 @@ group :development do
   gem "minitest", "< 6.0"
   gem "minitest-reporters"
   gem "mutex_m"
-  gem "opentelemetry-metrics-sdk"
-  gem "opentelemetry-sdk"
+  gem "opentelemetry-metrics-sdk", "~> 0.11.2"
+  gem "opentelemetry-sdk", "~> 1.10"
   gem "rack"
   gem "reek"
   gem "rubocop", require: false

--- a/ext/rcb_crud.cxx
+++ b/ext/rcb_crud.cxx
@@ -734,6 +734,7 @@ cb_Backend_document_append(VALUE self,
     cb_extract_content(req, content);
     cb_extract_timeout(req, options);
     cb_extract_durability_level(req, options);
+    cb_extract_cas(req, options);
 
     auto parent_span = cb_create_parent_span(req, self);
 
@@ -807,6 +808,7 @@ cb_Backend_document_prepend(VALUE self,
     cb_extract_content(req, content);
     cb_extract_timeout(req, options);
     cb_extract_durability_level(req, options);
+    cb_extract_cas(req, options);
 
     auto parent_span = cb_create_parent_span(req, self);
 

--- a/test/crud_test.rb
+++ b/test/crud_test.rb
@@ -818,6 +818,28 @@ module Couchbase
       assert_equal "barfoo", res.content
     end
 
+    def test_append_with_bad_cas
+      doc_id = uniq_id(:append)
+
+      res = @collection.upsert(doc_id, "foo", Options::Upsert(transcoder: RawBinaryTranscoder.new))
+
+      refute_equal 0, res.cas
+      assert_raises(Couchbase::Error::CasMismatch) do
+        @collection.binary.append(doc_id, "bar", Options::Append(cas: res.cas + 1))
+      end
+    end
+
+    def test_prepend_with_bad_cas
+      doc_id = uniq_id(:prepend)
+
+      res = @collection.upsert(doc_id, "foo", Options::Upsert(transcoder: RawBinaryTranscoder.new))
+
+      refute_equal 0, res.cas
+      assert_raises(Couchbase::Error::CasMismatch) do
+        @collection.binary.prepend(doc_id, "bar", Options::Prepend(cas: res.cas + 1))
+      end
+    end
+
     def test_multi_ops
       skip("#{name}: The #{Couchbase::Protostellar::NAME} protocol does not support multi ops") if env.protostellar?
 


### PR DESCRIPTION
## Motivation

The CAS option was being ignored in the append & prepend operations, and not being passed on to the C++ core.

## Changes

* Include the CAS in the core request, if provided.
* Add tests for append/prepend with bad CAS

