### PR TITLE
RCBC-543: Add consistency helper for update_collection tests

### DIFF
--- a/test/collection_manager_test.rb
+++ b/test/collection_manager_test.rb
@@ -297,6 +297,9 @@ module Couchbase
 
       settings = Management::UpdateCollectionSettings.new(history: true)
       @magma_collection_manager.update_collection(scope_name, collection_name, settings)
+      env.consistency.wait_until_collection_satisfies_predicate(TEST_MAGMA_BUCKET_NAME, scope_name, collection_name) do |c|
+        c["history"] == true
+      end
 
       coll = get_collection(scope_name, collection_name, @magma_collection_manager)
 
@@ -479,6 +482,9 @@ module Couchbase
 
       settings = Management::UpdateCollectionSettings.new(max_expiry: 1)
       @collection_manager.update_collection(scope_name, collection_name, settings)
+      env.consistency.wait_until_collection_satisfies_predicate(env.bucket, scope_name, collection_name) do |c|
+        c["maxTTL"] == 1
+      end
 
       coll_spec = get_collection(scope_name, collection_name)
 
@@ -529,6 +535,9 @@ module Couchbase
       settings = Management::UpdateCollectionSettings.new(max_expiry: -1)
 
       @collection_manager.update_collection(scope_name, collection_name, settings)
+      env.consistency.wait_until_collection_satisfies_predicate(env.bucket, scope_name, collection_name) do |c|
+        c["maxTTL"] == -1
+      end
 
       coll_spec = get_collection(scope_name, collection_name)
 

--- a/test/utils/consistency_helper.rb
+++ b/test/utils/consistency_helper.rb
@@ -129,6 +129,18 @@ module Couchbase
         end
       end
 
+      def wait_until_collection_satisfies_predicate(bucket_name, scope_name, collection_name, timeout: DEFAULT_TIMEOUT_SECS, &blk)
+        wait_until(timeout,
+                   "Collection `#{collection_name}` in scope `#{scope_name}` & bucket `#{bucket_name}` does not " \
+                   "satisfy the predicate at #{blk.source_location.join(':')} in all nodes") do
+          resource_satisfies_predicate("pools/default/buckets/#{bucket_name}/scopes") do |resp|
+            resp["scopes"].any? do |scope|
+              scope["name"] == scope_name && scope["collections"].any? { |c| c["name"] == collection_name && yield(c) }
+            end
+          end
+        end
+      end
+
       def wait_until_bucket_present_in_indexes(name, timeout: DEFAULT_TIMEOUT_SECS)
         wait_until(timeout, "Bucket `#{name}` is not present in the query service in all nodes") do
           @query_hosts.all? do |host|


### PR DESCRIPTION
The collection settings update happens asynchronously across the cluster. This results in `update_collection` intermittently failing on CI. This change adds a consistency helper for ensuring that the settings have been updated across all nodes, similar to what we have for creating and dropping collections.