### PR TITLE
RCBC-535: Upgrade to Minitest 6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,8 @@ group :development do
   gem "heckle"
   gem "irb"
   # TODO(SA): review https://minite.st/docs/History_rdoc.html#label-6.0.0+-2F+2025-12-17
-  gem "minitest", "< 6.0"
+  gem "minitest", "~> 6.0"
+  gem "minitest-mock"
   gem "minitest-reporters"
   gem "mutex_m"
   gem "opentelemetry-metrics-sdk", "~> 0.11.2"

--- a/test/scan_test.rb
+++ b/test/scan_test.rb
@@ -252,8 +252,6 @@ module Couchbase
     end
 
     def test_range_scan_concurrency
-      skip("Skipped until CXXCBC-345 is resolved")
-
       CONCURRENCY_VALUES.each do |c|
         expected_ids = (0..9).map { |i| "#{@shared_prefix}-1#{i}" } + (0..9).map { |i| "#{@shared_prefix}-2#{i}" }
         scan_result = @collection.scan(
@@ -268,8 +266,6 @@ module Couchbase
     end
 
     def test_prefix_scan_concurrency
-      skip("Skipped until CXXCBC-345 is resolved")
-
       CONCURRENCY_VALUES.each do |c|
         expected_ids = (0..9).map { |i| "#{@shared_prefix}-1#{i}" }
         scan_result = @collection.scan(PrefixScan.new("#{@shared_prefix}-1"),
@@ -279,8 +275,6 @@ module Couchbase
     end
 
     def test_sampling_scan_concurrency
-      skip("Skipped until CXXCBC-345 is resolved")
-
       CONCURRENCY_VALUES.each do |c|
         limit = 20
         scan_result = @collection.scan(SamplingScan.new(limit), Options::Scan.new(concurrency: c, mutation_state: @mutation_state))


### PR DESCRIPTION
The only change we need is adding `minitest-mock` as a dependency (no longer bundled with `minitest`), which is needed for the active support test cases.