### PR TITLE
RCBC-550: Access C++ log level using C++ core API instead of spdlog's default logger

### DIFF
--- a/ext/rcb_logger.cxx
+++ b/ext/rcb_logger.cxx
@@ -184,19 +184,19 @@ cb_Backend_set_log_level(VALUE /* self */, VALUE log_level)
 {
   Check_Type(log_level, T_SYMBOL);
   if (ID type = rb_sym2id(log_level); type == rb_intern("trace")) {
-    spdlog::set_level(spdlog::level::trace);
+    core::logger::set_log_levels(core::logger::level::trace);
   } else if (type == rb_intern("debug")) {
-    spdlog::set_level(spdlog::level::debug);
+    core::logger::set_log_levels(core::logger::level::debug);
   } else if (type == rb_intern("info")) {
-    spdlog::set_level(spdlog::level::info);
+    core::logger::set_log_levels(core::logger::level::info);
   } else if (type == rb_intern("warn")) {
-    spdlog::set_level(spdlog::level::warn);
+    core::logger::set_log_levels(core::logger::level::warn);
   } else if (type == rb_intern("error")) {
-    spdlog::set_level(spdlog::level::err);
+    core::logger::set_log_levels(core::logger::level::err);
   } else if (type == rb_intern("critical")) {
-    spdlog::set_level(spdlog::level::critical);
+    core::logger::set_log_levels(core::logger::level::critical);
   } else if (type == rb_intern("off")) {
-    spdlog::set_level(spdlog::level::off);
+    core::logger::set_log_levels(core::logger::level::off);
   } else {
     rb_raise(rb_eArgError, "Unsupported log level type: %+" PRIsVALUE, log_level);
     return Qnil;
@@ -207,23 +207,21 @@ cb_Backend_set_log_level(VALUE /* self */, VALUE log_level)
 static VALUE
 cb_Backend_get_log_level(VALUE /* self */)
 {
-  switch (spdlog::get_level()) {
-    case spdlog::level::trace:
+  switch (core::logger::get_lowest_log_level()) {
+    case core::logger::level::trace:
       return rb_id2sym(rb_intern("trace"));
-    case spdlog::level::debug:
+    case core::logger::level::debug:
       return rb_id2sym(rb_intern("debug"));
-    case spdlog::level::info:
+    case core::logger::level::info:
       return rb_id2sym(rb_intern("info"));
-    case spdlog::level::warn:
+    case core::logger::level::warn:
       return rb_id2sym(rb_intern("warn"));
-    case spdlog::level::err:
+    case core::logger::level::err:
       return rb_id2sym(rb_intern("error"));
-    case spdlog::level::critical:
+    case core::logger::level::critical:
       return rb_id2sym(rb_intern("critical"));
-    case spdlog::level::off:
+    case core::logger::level::off:
       return rb_id2sym(rb_intern("off"));
-    case spdlog::level::n_levels:
-      return Qnil;
   }
   return Qnil;
 }

--- a/test/couchbase_test.rb
+++ b/test/couchbase_test.rb
@@ -49,4 +49,29 @@ class CouchbaseTest < Minitest::Test
       cluster.disconnect
     end
   end
+
+  # Regression test for RCBC-550
+  def test_it_can_connect_after_process_fork
+    skip("Forking not supported on Windows") if Gem.win_platform?
+    skip("Forking not supported") unless Process.respond_to?(:fork)
+    skip("Cannot use gRPC before and after fork (unless GRPC_ENABLE_FORK_SUPPORT is set)") if env.protostellar?
+
+    pid = Process.fork do
+      # Connect in the child process
+      cluster = Couchbase::Cluster.connect(env.connection_string, env.username, env.password)
+
+      refute_nil cluster
+      cluster.disconnect
+    end
+
+    _, status = Process.wait2(pid)
+
+    assert_predicate status, :success?, "Child process failed with status #{status.exitstatus}"
+
+    # Connect in the parent process post-fork
+    cluster = Couchbase::Cluster.connect(env.connection_string, env.username, env.password)
+
+    refute_nil cluster
+    cluster.disconnect
+  end
 end


### PR DESCRIPTION
## Motivation

`Backend.get_log_level` results in a segmentation fault when used after a process fork. The reason for that is that we get the log level from spdlog's default logger, which is destroyed by the C++ SDK after the fork event (the SDK doesn't actually use spdlog's default logger). We should use the logger API provided by the C++ SDK instead of using the `spdlog` API directly. This affected `Cluster#connect` when using the default `ThresholdLoggerTracer` as it calls `Backend.get_log_level`

## Change

* Use the C++ SDK's logger API to access and set the log level, instead of directly using the `spdlog` API.