### PR TITLE
Rubocop: Fix Lint/SafeNavigationWithEmpty offenses

### DIFF
--- a/lib/couchbase/json_transcoder.rb
+++ b/lib/couchbase/json_transcoder.rb
@@ -35,7 +35,7 @@ module Couchbase
       format = TranscoderFlags.decode(flags).format
       raise Error::DecodingFailure, "Unable to decode #{format} with the JsonTranscoder" unless format == :json || format.nil?
 
-      JSON.parse(blob) unless blob&.empty?
+      JSON.parse(blob) unless blob && blob.empty?
     end
   end
 end

--- a/lib/couchbase/options.rb
+++ b/lib/couchbase/options.rb
@@ -107,7 +107,7 @@ module Couchbase
       # @api private
       # @return [Boolean]
       def need_projected_get?
-        @with_expiry || !@projections&.empty?
+        @with_expiry || (!@projections.nil? && !@projections.empty?)
       end
 
       # @api private
@@ -116,7 +116,7 @@ module Couchbase
           timeout: Utils::Time.extract_duration(@timeout),
         }
         options.update(with_expiry: true) if @with_expiry
-        unless @projections&.empty?
+        unless @projections.nil? || @projections.empty?
           options.update({
             projections: @projections,
             preserve_array_indexes: @preserve_array_indexes,

--- a/test/active_support/cache_store_test.rb
+++ b/test/active_support/cache_store_test.rb
@@ -17,12 +17,14 @@
 require_relative "../test_helper"
 
 require "active_support"
+require "logger"
 
 module Couchbase
   class CacheStoreTest < Minitest::Test
     include TestUtilities
 
     def setup
+      ActiveSupport::Cache::Store.logger = Logger.new($stderr)
       @cache = ActiveSupport::Cache.lookup_store(:couchbase_store, {
         connection_string: env.connection_string,
         username: env.username,

--- a/test/active_support/caching_test.rb
+++ b/test/active_support/caching_test.rb
@@ -31,6 +31,7 @@ module Couchbase
     include TestUtilities
 
     def lookup_store(options = {})
+      ActiveSupport::Cache::Store.logger = Logger.new($stderr)
       ActiveSupport::Cache.lookup_store(:couchbase_store, {
         connection_string: env.connection_string,
         username: env.username,

--- a/test/json_transcoder_test.rb
+++ b/test/json_transcoder_test.rb
@@ -58,6 +58,14 @@ module Couchbase
       assert_raises(Couchbase::Error::EncodingFailure) { @transcoder.encode(document) }
     end
 
+    def test_encode_nil
+      document = nil
+      encoded, flag = @transcoder.encode(document)
+
+      assert_equal "null", encoded
+      assert_equal 2, flag >> 24
+    end
+
     def test_decode_hash
       blob = "{\"foo\":10,\"bar\":\"baz\"}"
       flag = Couchbase::TranscoderFlags.new(format: :json).encode
@@ -87,6 +95,14 @@ module Couchbase
       flag = Couchbase::TranscoderFlags.new(format: :binary).encode
 
       assert_raises(Couchbase::Error::DecodingFailure) { @transcoder.decode(blob, flag) }
+    end
+
+    def test_decode_nil
+      blob = "null"
+      flag = Couchbase::TranscoderFlags.new(format: :json).encode
+      decoded = @transcoder.decode(blob, flag)
+
+      assert_nil decoded
     end
   end
 end


### PR DESCRIPTION
```
lib/couchbase/json_transcoder.rb:38:31: W: [Correctable] Lint/SafeNavigationWithEmpty: Avoid calling empty? with the safe navigation operator in conditionals.
      JSON.parse(blob) unless blob&.empty?
                              ^^^^^^^^^^^^
lib/couchbase/options.rb:119:16: W: [Correctable] Lint/SafeNavigationWithEmpty: Avoid calling empty? with the safe navigation operator in conditionals.
        unless @projections&.empty?
               ^^^^^^^^^^^^^^^^^^^^
```