### PR TITLE
Allow manual dispatch of CI workflows

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
       - release*
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+-*'
   pull_request:
     branches:
       - main

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -2,6 +2,7 @@ name: linters
 permissions: {}
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,7 @@ name: tests
 permissions: {}
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
       - release*
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+-*'
   pull_request:
     branches:
       - main


### PR DESCRIPTION
Add a workflow_dispatch trigger to the tests and linters workflows so they can be started manually for a given ref, in addition to the push and pull_request triggers.