### PR TITLE
RCBC-551: FIT performer - add support for CounterEq bounds type

### DIFF
--- a/fit-performer/lib/fit/performer/bounds.rb
+++ b/fit-performer/lib/fit/performer/bounds.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+#  Copyright 2026-Present Couchbase, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+require_relative 'bounds/simple'
+require_relative 'bounds/for_time'
+require_relative 'bounds/counter_equality'
+require_relative 'bounds/counter'
+
+module FIT
+  module Performer
+    module Bounds
+      def self.create_bounds(raw_workload, global_counters)
+        return Simple.new(raw_workload.command.size) unless raw_workload.has_bounds?
+
+        raw_bounds = raw_workload.bounds
+        case raw_bounds.bounds
+        when :counter
+          counter_id = raw_bounds.counter.counter_id
+          initial_value = raw_bounds.counter.global.count
+          global_counter = global_counters.get_counter(counter_id, initial_value)
+          Counter.new(global_counter)
+
+        when :for_time
+          ForTime.new(raw_bounds.for_time.seconds)
+
+        when :counter_eq
+          counter_id = raw_bounds.counter_eq.counter_id
+          initial_value = raw_bounds.counter_eq.global.count
+          global_counter = global_counters.get_counter(counter_id, initial_value)
+          CounterEquality.new(global_counter, initial_value)
+
+        else
+          raise PerformerError, "Bounds type `#{raw_bounds.bounds}` not recognised"
+        end
+      end
+    end
+  end
+end

--- a/fit-performer/lib/fit/performer/bounds/counter.rb
+++ b/fit-performer/lib/fit/performer/bounds/counter.rb
@@ -14,19 +14,22 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-require 'fit/performer/workloads/sdk_workload'
-require 'fit/performer/performer_error'
-
 module FIT
   module Performer
-    module Workloads
-      def self.build_workload(raw_workload, connection, run_id, stream_owner, span_owner, global_counters)
-        workload_type = raw_workload.workload
-        case workload_type
-        when :sdk
-          SdkWorkload.new(raw_workload.sdk, connection, run_id, stream_owner, span_owner, global_counters)
-        else
-          raise PerformerError, "Workload type `#{workload_type}` not supported"
+    module Bounds
+      # A bounds implementation that executes commands for a specified number of times, based on a global counter.
+      # The global counter may be shared with other workloads.
+      class Counter
+        # Initializes a new instance of the Counter bounds implementation.
+        #
+        # @param global_counter [Concurrent::AtomicFixnum] The global counter to use for determining if the workload
+        # can execute.
+        def initialize(global_counter)
+          @global_counter = global_counter
+        end
+
+        def can_execute?
+          @global_counter.decrement >= 0
         end
       end
     end

--- a/fit-performer/lib/fit/performer/bounds/counter_equality.rb
+++ b/fit-performer/lib/fit/performer/bounds/counter_equality.rb
@@ -14,19 +14,23 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-require 'fit/performer/workloads/sdk_workload'
-require 'fit/performer/performer_error'
-
 module FIT
   module Performer
-    module Workloads
-      def self.build_workload(raw_workload, connection, run_id, stream_owner, span_owner, global_counters)
-        workload_type = raw_workload.workload
-        case workload_type
-        when :sdk
-          SdkWorkload.new(raw_workload.sdk, connection, run_id, stream_owner, span_owner, global_counters)
-        else
-          raise PerformerError, "Workload type `#{workload_type}` not supported"
+    module Bounds
+      # A bounds implementation that executes commands while a global counter remains unchanged.
+      class CounterEquality
+        # Initializes a new instance of the CounterEquality bounds implementation.
+        #
+        # @param global_counter [Concurrent::AtomicFixnum] The global counter to use for determining if the workload
+        # can execute.
+        # @param initial_value [Integer] The initial value of the counter to compare against
+        def initialize(global_counter, initial_value)
+          @global_counter = global_counter
+          @initial_value = initial_value
+        end
+
+        def can_execute?
+          @global_counter.value == @initial_value
         end
       end
     end

--- a/fit-performer/lib/fit/performer/bounds/for_time.rb
+++ b/fit-performer/lib/fit/performer/bounds/for_time.rb
@@ -14,19 +14,17 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-require 'fit/performer/workloads/sdk_workload'
-require 'fit/performer/performer_error'
-
 module FIT
   module Performer
-    module Workloads
-      def self.build_workload(raw_workload, connection, run_id, stream_owner, span_owner, global_counters)
-        workload_type = raw_workload.workload
-        case workload_type
-        when :sdk
-          SdkWorkload.new(raw_workload.sdk, connection, run_id, stream_owner, span_owner, global_counters)
-        else
-          raise PerformerError, "Workload type `#{workload_type}` not supported"
+    module Bounds
+      # A bounds implementation that executes commands for a specified duration of time.
+      class ForTime
+        def initialize(duration_seconds)
+          @deadline = Time.now + duration_seconds
+        end
+
+        def can_execute?
+          Time.now < @deadline
         end
       end
     end

--- a/fit-performer/lib/fit/performer/bounds/simple.rb
+++ b/fit-performer/lib/fit/performer/bounds/simple.rb
@@ -14,19 +14,18 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-require 'fit/performer/workloads/sdk_workload'
-require 'fit/performer/performer_error'
-
 module FIT
   module Performer
-    module Workloads
-      def self.build_workload(raw_workload, connection, run_id, stream_owner, span_owner, global_counters)
-        workload_type = raw_workload.workload
-        case workload_type
-        when :sdk
-          SdkWorkload.new(raw_workload.sdk, connection, run_id, stream_owner, span_owner, global_counters)
-        else
-          raise PerformerError, "Workload type `#{workload_type}` not supported"
+    module Bounds
+      # A simple bounds implementation that executes every command in the workload once.
+      class Simple
+        def initialize(command_count)
+          @remaining_command_count = command_count
+        end
+
+        def can_execute?
+          @remaining_command_count -= 1
+          @remaining_command_count >= 0
         end
       end
     end

--- a/fit-performer/lib/fit/performer/counters.rb
+++ b/fit-performer/lib/fit/performer/counters.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+#  Copyright 2026-Present Couchbase, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+require 'concurrent/atomic/atomic_fixnum'
+
+module FIT
+  module Performer
+    class Counters
+      def initialize
+        @counters = {}
+        @mutex = Mutex.new
+      end
+
+      def clear
+        @mutex.synchronize do
+          @counters.clear
+        end
+      end
+
+      def set_counter_value(counter_id, value)
+        @mutex.synchronize do
+          if @counters.key?(counter_id)
+            @counters[counter_id].value = value
+          else
+            @counters[counter_id] = Concurrent::AtomicFixnum.new(value)
+          end
+        end
+      end
+
+      def get_counter(counter_id, initial_value = nil)
+        @mutex.synchronize do
+          return @counters[counter_id] if @counters.key?(counter_id)
+
+          raise PerformerError, "Counter #{counter_id} does not exist and no initial value was provided" if initial_value.nil?
+
+          @counters[counter_id] = Concurrent::AtomicFixnum.new(initial_value)
+        end
+      end
+    end
+  end
+end

--- a/fit-performer/lib/fit/performer/multi_thread_executor.rb
+++ b/fit-performer/lib/fit/performer/multi_thread_executor.rb
@@ -22,21 +22,20 @@ module FIT
     class MultiThreadExecutor
       attr_reader :results
 
-      def initialize(connection, run_id, stream_owner, span_owner)
+      def initialize(connection, run_id, stream_owner, span_owner, global_counters)
         @logger = Logger.new($stdout)
         @results = Queue.new
         @connection = connection
         @run_id = run_id
         @stream_owner = stream_owner
         @span_owner = span_owner
-        @global_counters = {}
-        @global_semaphore = Mutex.new
+        @global_counters = global_counters
       end
 
       def build_workloads(request)
         @workloads = request.workloads.horizontal_scaling.map do |h|
           h.workloads.map do |w|
-            Workloads.build_workload(w, @connection, @run_id, @stream_owner, @span_owner)
+            Workloads.build_workload(w, @connection, @run_id, @stream_owner, @span_owner, @global_counters)
           end
         end
       end
@@ -44,8 +43,7 @@ module FIT
       def start_workload_thread(workloads)
         Thread.new do # rubocop:disable ThreadSafety/NewThread
           workloads.each do |w|
-            w.set_bounds(@global_counters, @global_semaphore)
-            w.execute(@results, @global_counters, @global_semaphore)
+            w.execute(@results)
           end
         end
       end
@@ -69,8 +67,8 @@ module FIT
         end
       end
 
-      def self.build_executor(request, connection, run_id, stream_owner, span_owner)
-        executor = MultiThreadExecutor.new(connection, run_id, stream_owner, span_owner)
+      def self.build_executor(request, connection, run_id, stream_owner, span_owner, global_counters)
+        executor = MultiThreadExecutor.new(connection, run_id, stream_owner, span_owner, global_counters)
         executor.build_workloads(request)
         executor
       end

--- a/fit-performer/lib/fit/performer/service.rb
+++ b/fit-performer/lib/fit/performer/service.rb
@@ -27,6 +27,7 @@ require 'fit/performer/multi_thread_executor'
 require 'fit/performer/request_executor'
 require 'fit/performer/streaming'
 require 'fit/performer/observability/span_owner'
+require 'fit/performer/counters'
 
 require 'fit/protocol/performer_services_pb'
 require 'fit/protocol/performer.caps_pb'
@@ -95,6 +96,7 @@ module FIT
         @connections = Connections.new
         @stream_owner = Streaming::StreamOwner.new
         @span_owner = Observability::SpanOwner.new
+        @global_counters = Counters.new
         @logger.info("Using Ruby SDK version #{SDK_VERSION}")
       end
 
@@ -144,7 +146,7 @@ module FIT
           begin
             connection = @connections[request.workloads.cluster_connection_id]
             workload_executor = MultiThreadExecutor.build_executor(
-              request, connection, run_id, @stream_owner, @span_owner
+              request, connection, run_id, @stream_owner, @span_owner, @global_counters
             )
             @logger.info("Created the workload executor")
             req_executor = RequestExecutor.build_request(workload_executor, request)
@@ -187,6 +189,16 @@ module FIT
         FIT::Protocol::Observability::SpanFinishResponse.new
       rescue PerformerError => e
         raise GRPC::FailedPrecondition, e.message
+      end
+
+      def set_counter(request, _call)
+        @global_counters.set_counter_value(request.counter_id, request.global.count)
+        FIT::Protocol::Shared::SetCounterResponse.new
+      end
+
+      def clear_all_counters(_request, _call)
+        @global_counters.clear
+        FIT::Protocol::Shared::ClearAllCountersResponse.new
       end
     end
   end

--- a/fit-performer/lib/fit/performer/workloads/base_workload.rb
+++ b/fit-performer/lib/fit/performer/workloads/base_workload.rb
@@ -15,12 +15,13 @@
 #  limitations under the License.
 
 require 'fit/performer/performer_error'
+require 'fit/performer/bounds'
 
 module FIT
   module Performer
     module Workloads
       class BaseWorkload
-        def initialize(raw_workload, connection, run_id, stream_owner, span_owner)
+        def initialize(raw_workload, connection, run_id, stream_owner, span_owner, global_counters)
           @logger = Logger.new($stdout)
           @raw_workload = raw_workload
           @connection = connection
@@ -28,61 +29,11 @@ module FIT
           @stream_owner = stream_owner
           @span_owner = span_owner
           @command_count = @raw_workload.command.size
-
-          # Bounds-related attributes
-          @counter_id = nil
-          @deadline = nil
-          @remaining_command_count = nil
+          @bounds = Bounds.create_bounds(@raw_workload, global_counters)
         end
 
-        def execute(_results, _global_counters, _global_semaphore)
+        def execute(_results)
           raise "`execute` method must be implemented"
-        end
-
-        def set_bounds(global_counters, global_semaphore)
-          unless @raw_workload.has_bounds?
-            @remaining_command_count = @command_count
-            return
-          end
-
-          raw_bounds = @raw_workload.bounds
-          case raw_bounds.bounds
-          when :counter
-            raw_counter = raw_bounds.counter
-            @counter_id = raw_counter.counter_id
-
-            case raw_counter.counter
-            when :global
-              global_semaphore.synchronize do
-                unless global_counters.include?(@counter_id)
-                  initial_count = raw_counter.global.count
-                  global_counters[@counter_id] = initial_count
-                end
-              end
-            else
-              raise PerformerError, "Counter type `#{counter.counter}` not recognised"
-            end
-          when :for_time
-            @deadline = Time.now + raw_bounds.for_time.seconds
-          else
-            raise PerformerError, "Bounds type `#{@raw_workload.bounds}` not recognised"
-          end
-        end
-
-        def within_bounds(global_counters, global_semaphore)
-          if !@counter_id.nil?
-            global_semaphore.synchronize do
-              global_counters[@counter_id] -= 1
-              global_counters[@counter_id] >= 0
-            end
-          elsif !@deadline.nil?
-            Time.now < @deadline
-          elsif !@remaining_command_count.nil?
-            @remaining_command_count -= 1
-            @remaining_command_count >= 0
-          else
-            raise PerformerError, "Bounds have not been set"
-          end
         end
 
         private

--- a/fit-performer/lib/fit/performer/workloads/sdk_workload.rb
+++ b/fit-performer/lib/fit/performer/workloads/sdk_workload.rb
@@ -22,14 +22,14 @@ module FIT
   module Performer
     module Workloads
       class SdkWorkload < BaseWorkload
-        def initialize(raw_workload, connection, run_id, stream_owner, span_owner)
+        def initialize(raw_workload, connection, run_id, stream_owner, span_owner, global_counters)
           super
           @logger = Logger.new($stdout)
         end
 
-        def execute(results, global_counters, global_semaphore)
+        def execute(results)
           executed_cmd_count = 0
-          while within_bounds(global_counters, global_semaphore)
+          while @bounds.can_execute?
             raw_cmd = @raw_workload.command[executed_cmd_count % @command_count]
             execute_command(raw_cmd, executed_cmd_count, results)
             executed_cmd_count += 1


### PR DESCRIPTION
Should be merged after https://github.com/couchbase/couchbase-ruby-client/pull/237

## Changes

* Adding support for the CounterEq bounds type, where the driver effectively tells the performer when to stop executing the workload
* Implement the SetCounter and ClearAllCounters RPCs
* Refactored the bounds code more generally, and created classes for the bounds type that implement the same interface (`#can_execute?`)
* Counters are now global at the performer-level (as required by the new spec) and represented by a `Concurrent::AtomicFixnum`